### PR TITLE
PoC Time+Date manipulation blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ build/Release
 
 # Dependency directories
 node_modules/
+win_node_modules/
 jspm_packages/
 
 # Snowpack dependency directory (https://snowpack.dev/)
@@ -140,3 +141,6 @@ docs/blockly/*
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# random trash
+.playwright-mcp/

--- a/TIME_TODO.md
+++ b/TIME_TODO.md
@@ -116,4 +116,5 @@ Update `app/toolbox/time.js` contents array:
 - [ ] Consider merging the two extract blocks into one with combined time+date segment dropdown (Hour, Minute, Second, Year, Month, Day, Day of Week, Week Number)
 - [ ] Confirm Duration block works with weather block timestamps e.g. `Sunset - Duration(2 hours)`
 - [ ] Extend "DateTime block" to also allow Day = -1 for last day of month (end of list, called "Last Day of Month (-1)")
-  
+- [ ] Need a feed property block, to extract feed key/last_value aka previous value/updated_at/created_at[utc]/unit-type/unit-symbol/status/etc (check api)
+- [ ] Future work - Try to ensure all timestamps are UTC/usertime.

--- a/TIME_TODO.md
+++ b/TIME_TODO.md
@@ -101,18 +101,19 @@ Update `app/toolbox/time.js` contents array:
 - [x] DateTime to Text block with timezone + format mutator
 - [x] Text to DateTime block with timezone + format mutator
 - [x] Format option blocks (`fmt_iso8601`, `fmt_rfc2822`, `fmt_unix`, `fmt_preset`, `fmt_custom`)
+- [x] Duration block with timezone mutator (seconds/minutes/hours/days/weeks/months/years)
 - [x] All blocks registered in Time toolbox
 - [x] Block images generated
 - [x] Comprehensive tests including historical dates (Battle of Hastings, Millennium, Y2038, 2050, 2070)
 
 ### Remaining 🔲
 
-- [ ] Convert Seconds to DateTime block with **dual timezone slots** (input + output)
+- [ ] Add "Convert Seconds to DateTime block" with **dual timezone slots** (input + output), or just use parse block with unit time.
 - [ ] `tz_io_server.js` - "IO Server Time (EST)" option
 - [ ] `tz_location_coords.js` - Location-based timezone from coordinates
 - [ ] Auto timezone inheritance from child blocks
 - [ ] Icon SVGs for blocks (currently using default icons)
-- [ ] Consider merging the two extract time blocks, add Week number, Day of Week (Mon 0-6 Sun). 
-- [ ] Also a "Create Duration" block, to Add Days/Weeks/Years/ or verify if possible with existing blocks in seconds + Math e.g. +3hrs to a string time/date.
-- [ ] Confirm it works with weather block timestamps e.g. Sunset - 2hrs
- 
+- [ ] Consider merging the two extract blocks into one with combined time+date segment dropdown (Hour, Minute, Second, Year, Month, Day, Day of Week, Week Number)
+- [ ] Confirm Duration block works with weather block timestamps e.g. `Sunset - Duration(2 hours)`
+- [ ] Extend "DateTime block" to also allow Day = -1 for last day of month (end of list, called "Last Day of Month (-1)")
+  

--- a/TIME_TODO.md
+++ b/TIME_TODO.md
@@ -1,0 +1,86 @@
+# Plan: Add Time Extraction & Conversion Blocks with Timezone Support
+
+Create three new blocks: **Extract Time Segment**, **Extract Date Segment**, and **Convert Seconds to DateTime**. Each has a settings cog mutator for timezone configuration. Timezone option blocks are shared, but mutators differ based on whether they need one or two timezone slots.
+
+Similar pattern to the `json_path_query.js` block for extraction logic, and `action_settings/mutator.js` for the settings cog pattern.
+
+## Context
+
+- The existing `time.js` block outputs timezone-less seconds (effectively just date and timezoneless in seconds)
+- Docs are auto-generated, no need to create documentation manually
+- Use Playwright to test after building with `npm run start`
+
+## Steps
+
+### 1. Create shared timezone option blocks in `app/blocks/utility/timezone/`
+
+- `tz_io_account.js` - "IO Account Timezone" (default for user-derived values, e.g., user's account is Europe/London so it auto adjusts)
+- `tz_io_server.js` - "IO Server Time (EST)" (default for feeds `updated_at` property and other template-related properties)
+- `tz_preset.js` - Dropdown with preset timezones: UTC, Europe/London, America/New_York, America/Los_Angeles (PDT)
+- `tz_location_coords.js` - "Location: Lat:<input value for latitude>, Long:<input for longitude>"
+- `tz_fixed_offset.js` - "Fixed UTC Offset <+/-><hours>:<minutes>"
+- All output type `timezone` for connection compatibility
+
+### 2. Create Extract Time Segment block
+
+Location: `app/blocks/utility/extract_time_segment.js`
+
+- Clock/watch + scissors symbol/glyph/image icon
+- Similar to the `json_path_query.js` block but for extracting time segments
+- `SEGMENT` dropdown (Hour/Minute/Second)
+- `TIME` input (accepts time in seconds)
+- Create `extract_time_segment/mutator.js` with **single timezone slot** (input timezone only)
+- Settings cog (mutator) allows optional timezone setting for the passed-in value
+
+### 3. Create Extract Date Segment block
+
+Location: `app/blocks/utility/extract_date_segment.js`
+
+- Calendar + scissors icon
+- `SEGMENT` dropdown (Year/Month/Day/Day of Week)
+- `DATE` input (accepts seconds)
+- Create `extract_date_segment/mutator.js` with **single timezone slot** (input timezone only)
+
+### 4. Create Convert Seconds to DateTime block
+
+Location: `app/blocks/utility/convert_seconds_datetime.js`
+
+- Clock + arrows icon
+- `SECONDS` input (int) with input timezone setting block
+- Create `convert_seconds_datetime/mutator.js` with **dual timezone slots** (input timezone + output timezone)
+- Outputs the same int passed through datetime conversion based on input and output timezones in the mutator
+
+### 5. Create DateTime block
+
+Location: `app/blocks/utility/datetime.js`
+
+- Calendar + clock icon
+- `DAY` field (1-31 dropdown)
+- `MONTH` field (1-12 dropdown or month names)
+- `YEAR` field (number input or dropdown of reasonable years)
+- `TIME` input (prepopulated with `io_utility_time` block as shadow)
+- Creates a datetime value by adding the time to the date at midnight in the correct timezone
+- Create `datetime/mutator.js` with **single timezone slot** (timezone for the date/time calculation)
+- Outputs seconds representing the full datetime
+
+### 6. Update Current Time block
+
+Location: `app/blocks/utility/current_time.js`
+
+- Add optional settings cog mutator with **single timezone slot** (output timezone)
+- Default: IO Account Timezone
+- Allows picking another option from default of user timezone
+
+### 7. Register all blocks in toolbox
+
+Update `app/toolbox/time.js` contents array:
+- `io_utility_extract_time_segment`
+- `io_utility_extract_date_segment`
+- `io_utility_convert_seconds_datetime`
+- `io_utility_datetime`
+
+## Considerations
+
+1. **Mutator flyout blocks** - Each mutator needs a container block (`timezone_settings.js` for single, `timezone_conversion_settings.js` for dual). These can be shared since the timezone option blocks inside the mutators are shared, but some mutators have two (input + output) timezones needed, and others just one.
+
+2. **Icon SVGs** - Generate base64-encoded clock+scissors, calendar+scissors, and clock+arrows SVGs during implementation.

--- a/TIME_TODO.md
+++ b/TIME_TODO.md
@@ -84,3 +84,35 @@ Update `app/toolbox/time.js` contents array:
 1. **Mutator flyout blocks** - Each mutator needs a container block (`timezone_settings.js` for single, `timezone_conversion_settings.js` for dual). These can be shared since the timezone option blocks inside the mutators are shared, but some mutators have two (input + output) timezones needed, and others just one.
 
 2. **Icon SVGs** - Generate base64-encoded clock+scissors, calendar+scissors, and clock+arrows SVGs during implementation.
+
+3. **Auto Timezone Option** - Blocks with time-related inputs should have an "Auto" timezone option that inherits the timezone from the connected child input block. If the child block doesn't specify a timezone, fall back to user's IO Account timezone. This allows seamless chaining of time blocks without manual timezone configuration at each step.
+
+4. **Simple Time Comparisons (Current Time + Time blocks)** - The `time.js` and `current_time.js` blocks are designed for simple time-of-day comparisons like "is it after 5:30?" or "is current time between 9:00 and 17:00?". These blocks work in the user's local timezone context by default. See Justin's POC docs for confirmed use cases. The time block outputs seconds-since-midnight for easy numeric comparison.
+
+## Implementation Status
+
+### Completed ✅
+
+- [x] Timezone option blocks (`tz_io_account`, `tz_utc`, `tz_device`, `tz_preset`, `tz_fixed_offset`)
+- [x] Extract Time Segment block with timezone mutator
+- [x] Extract Date Segment block with timezone mutator  
+- [x] DateTime block with timezone mutator
+- [x] Current Time block with timezone mutator
+- [x] DateTime to Text block with timezone + format mutator
+- [x] Text to DateTime block with timezone + format mutator
+- [x] Format option blocks (`fmt_iso8601`, `fmt_rfc2822`, `fmt_unix`, `fmt_preset`, `fmt_custom`)
+- [x] All blocks registered in Time toolbox
+- [x] Block images generated
+- [x] Comprehensive tests including historical dates (Battle of Hastings, Millennium, Y2038, 2050, 2070)
+
+### Remaining 🔲
+
+- [ ] Convert Seconds to DateTime block with **dual timezone slots** (input + output)
+- [ ] `tz_io_server.js` - "IO Server Time (EST)" option
+- [ ] `tz_location_coords.js` - Location-based timezone from coordinates
+- [ ] Auto timezone inheritance from child blocks
+- [ ] Icon SVGs for blocks (currently using default icons)
+- [ ] Consider merging the two extract time blocks, add Week number, Day of Week (Mon 0-6 Sun). 
+- [ ] Also a "Create Duration" block, to Add Days/Weeks/Years/ or verify if possible with existing blocks in seconds + Math e.g. +3hrs to a string time/date.
+- [ ] Confirm it works with weather block timestamps e.g. Sunset - 2hrs
+ 

--- a/app/blocks/utility/convert_seconds_datetime.js
+++ b/app/blocks/utility/convert_seconds_datetime.js
@@ -1,0 +1,69 @@
+import mutator from './convert_seconds_datetime/mutator.js'
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_convert_seconds_datetime',
+  bytecodeKey: "convertSecondsDatetime",
+  name: "Convert Timezone",
+  color: 360,
+  description: "Convert a timestamp from one timezone to another. Takes seconds as input and outputs seconds adjusted for the timezone difference. Use the settings cog to configure both the input timezone (what the timestamp is currently in) and output timezone (what you want to convert it to). Essential for working with feed data from different time sources.",
+
+  connections: {
+    mode: "value",
+    output: ["expression", "time"],
+  },
+
+  mutator,
+
+  template: `
+    Convert Timezone |CENTER
+    %SECONDS
+  `,
+
+  inputs: {
+    SECONDS: {
+      description: "The timestamp in seconds to convert between timezones. This can come from feed timestamps, datetime blocks, or any expression that evaluates to seconds.",
+      check: ["expression", "time"],
+      shadow: 'io_utility_current_time'
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const 
+        seconds = generator.valueToCode(block, 'SECONDS', 0) || 'null',
+        inputTimezoneType = block.inputTimezoneType || 'tz_io_server',
+        outputTimezoneType = block.outputTimezoneType || 'tz_io_account'
+      
+      return [JSON.stringify({
+        convertSecondsDatetime: {
+          seconds: JSON.parse(seconds),
+          inputTimezone: { type: inputTimezoneType },
+          outputTimezone: { type: outputTimezoneType }
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { convertSecondsDatetime } = blockObject
+      if (!convertSecondsDatetime) {
+        throw new Error("No convertSecondsDatetime data for io_utility_convert_seconds_datetime regenerator")
+      }
+      
+      const { seconds, inputTimezone, outputTimezone } = convertSecondsDatetime
+      
+      return {
+        type: 'io_utility_convert_seconds_datetime',
+        inputs: {
+          SECONDS: helpers.expressionToBlock(seconds, { shadow: 'io_utility_current_time' })
+        },
+        extraState: {
+          inputTimezoneType: inputTimezone?.type || 'tz_io_server',
+          outputTimezoneType: outputTimezone?.type || 'tz_io_account'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/convert_seconds_datetime/mutator.js
+++ b/app/blocks/utility/convert_seconds_datetime/mutator.js
@@ -1,0 +1,59 @@
+/** Dual timezone slot mutator for Convert Seconds to DateTime */
+export default {
+  inputTimezoneType: 'tz_io_server',
+  outputTimezoneType: 'tz_io_account',
+
+  saveExtraState: function() {
+    return {
+      inputTimezoneType: this.inputTimezoneType,
+      outputTimezoneType: this.outputTimezoneType
+    }
+  },
+
+  loadExtraState: function({ inputTimezoneType, outputTimezoneType }) {
+    this.inputTimezoneType = inputTimezoneType || 'tz_io_server'
+    this.outputTimezoneType = outputTimezoneType || 'tz_io_account'
+  },
+
+  flyoutBlockTypes: ['tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset'],
+
+  decompose: function(workspace) {
+    // Initialize the top-level block for the sub-diagram
+    const settingsBlock = workspace.newBlock('convert_tz_settings')
+    settingsBlock.initSvg()
+
+    // Create the input timezone block based on saved state
+    const inputTimezoneBlock = workspace.newBlock(this.inputTimezoneType)
+    inputTimezoneBlock.initSvg()
+
+    // Connect input timezone
+    const
+      { connection: inputConnection } = settingsBlock.getInput("INPUT_TIMEZONE"),
+      { outputConnection: inputOutput } = inputTimezoneBlock
+
+    inputConnection.connect(inputOutput)
+    inputConnection.setShadowState({ type: 'tz_io_server' })
+
+    // Create the output timezone block based on saved state
+    const outputTimezoneBlock = workspace.newBlock(this.outputTimezoneType)
+    outputTimezoneBlock.initSvg()
+
+    // Connect output timezone
+    const
+      { connection: outputConnection } = settingsBlock.getInput("OUTPUT_TIMEZONE"),
+      { outputConnection: outputOutput } = outputTimezoneBlock
+
+    outputConnection.connect(outputOutput)
+    outputConnection.setShadowState({ type: 'tz_io_account' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const inputTimezoneInput = settingsBlock.getInputTargetBlock("INPUT_TIMEZONE")
+    this.inputTimezoneType = inputTimezoneInput?.type || 'tz_io_server'
+
+    const outputTimezoneInput = settingsBlock.getInputTargetBlock("OUTPUT_TIMEZONE")
+    this.outputTimezoneType = outputTimezoneInput?.type || 'tz_io_account'
+  }
+}

--- a/app/blocks/utility/convert_seconds_datetime/timezone_conversion_settings.js
+++ b/app/blocks/utility/convert_seconds_datetime/timezone_conversion_settings.js
@@ -1,0 +1,32 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "convert_tz_settings",
+  name: "Timezone Conversion Settings",
+  colour: 360,
+  description: "Configure both input and output timezones for datetime conversion",
+
+  connections: { },
+
+  template: `
+    Timezone Conversion |CENTER
+    Input Timezone: %INPUT_TIMEZONE
+    Output Timezone: %OUTPUT_TIMEZONE
+  `,
+
+  inputs: {
+    INPUT_TIMEZONE: {
+      description: "The timezone the input value is currently in",
+      check: 'timezone',
+      shadow: 'tz_io_server',
+    },
+    OUTPUT_TIMEZONE: {
+      description: "The timezone to convert the value to",
+      check: 'timezone',
+      shadow: 'tz_io_account',
+    }
+  },
+
+  generators: {
+    json: () => [ {}, 0 ]
+  }
+}

--- a/app/blocks/utility/current_time.js
+++ b/app/blocks/utility/current_time.js
@@ -1,0 +1,30 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_current_time',
+  name: "Current Time",
+  color: 360,
+  description: "Get the current system time in 24-hour format for use in time comparisons and conditions. Returns the current hour and minute as a time value that can be compared with Time blocks. Perfect for creating time-based automation logic like 'if current time > 14:30' or 'if current time is between 9:00 and 17:00'. Found in the Time category alongside Time block.",
+  connections: {
+    mode: "value",
+    output: ["expression", "time"],
+  },
+  template: "Current Time",
+  generators: {
+    json: () => {
+      return [JSON.stringify({
+        currentTime: {}
+      }), 0]
+    }
+  },
+  regenerators: {
+    json: (blockObject, helpers) => {
+      if (!blockObject.currentTime) {
+        throw new Error("No currentTime data for io_utility_current_time regenerator")
+      }
+      
+      return {
+        type: 'io_utility_current_time'
+      }
+    }
+  }
+}

--- a/app/blocks/utility/current_time.js
+++ b/app/blocks/utility/current_time.js
@@ -1,18 +1,25 @@
+import mutator from './current_time/mutator.js'
+
 /** @type {import('#types').BlockDefinitionRaw} */
 export default {
   type: 'io_utility_current_time',
   name: "Current Time",
   color: 360,
-  description: "Get the current system time in 24-hour format for use in time comparisons and conditions. Returns the current hour and minute as a time value that can be compared with Time blocks. Perfect for creating time-based automation logic like 'if current time > 14:30' or 'if current time is between 9:00 and 17:00'. Found in the Time category alongside Time block.",
+  description: "Get the current system time in 24-hour format for use in time comparisons and conditions. Returns the current hour and minute as a time value that can be compared with Time blocks. Perfect for creating time-based automation logic like 'if current time > 14:30' or 'if current time is between 9:00 and 17:00'. Use the settings cog to select a different timezone (defaults to your IO Account timezone). Found in the Time category alongside Time block.",
   connections: {
     mode: "value",
     output: ["expression", "time"],
   },
+  mutator,
   template: "Current Time",
   generators: {
-    json: () => {
+    json: (block) => {
+      const timezoneType = block.timezoneType || 'tz_io_account'
+      
       return [JSON.stringify({
-        currentTime: {}
+        currentTime: {
+          timezone: { type: timezoneType }
+        }
       }), 0]
     }
   },
@@ -22,8 +29,13 @@ export default {
         throw new Error("No currentTime data for io_utility_current_time regenerator")
       }
       
+      const { timezone } = blockObject.currentTime
+      
       return {
-        type: 'io_utility_current_time'
+        type: 'io_utility_current_time',
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account'
+        }
       }
     }
   }

--- a/app/blocks/utility/current_time/mutator.js
+++ b/app/blocks/utility/current_time/mutator.js
@@ -1,0 +1,41 @@
+/** Single timezone slot mutator for Current Time block */
+export default {
+  timezoneType: 'tz_io_account',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType
+    }
+  },
+
+  loadExtraState: function({ timezoneType }) {
+    this.timezoneType = timezoneType || 'tz_io_account'
+  },
+
+  flyoutBlockTypes: ['tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset'],
+
+  decompose: function(workspace) {
+    // Initialize the top-level block for the sub-diagram
+    const settingsBlock = workspace.newBlock('current_time_tz_settings')
+    settingsBlock.initSvg()
+
+    // Create the timezone block based on saved state
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+
+    // Connect it to the settings block
+    const
+      { connection } = settingsBlock.getInput("TIMEZONE"),
+      { outputConnection } = timezoneBlock
+
+    connection.connect(outputConnection)
+    connection.setShadowState({ type: 'tz_io_account' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+  }
+}

--- a/app/blocks/utility/current_time/timezone_settings.js
+++ b/app/blocks/utility/current_time/timezone_settings.js
@@ -1,0 +1,26 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "current_time_tz_settings",
+  name: "Current Time Timezone Settings",
+  colour: 360,
+  description: "Configure the timezone for the current time output",
+
+  connections: { },
+
+  template: `
+    Current Time Settings |CENTER
+    Timezone: %TIMEZONE
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      description: "The timezone to use for the current time value",
+      check: 'timezone',
+      shadow: 'tz_io_account',
+    }
+  },
+
+  generators: {
+    json: () => [ {}, 0 ]
+  }
+}

--- a/app/blocks/utility/datetime.js
+++ b/app/blocks/utility/datetime.js
@@ -1,0 +1,131 @@
+import mutator from './datetime/mutator.js'
+import { makeOptions } from "#app/util/fields.js"
+
+// Generate year options from 2020 to 2035
+const yearOptions = makeOptions({
+  from: 2020,
+  upTo: 2036,
+  valueFunc: y => y.toString()
+})
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_datetime',
+  bytecodeKey: "datetime",
+  name: "DateTime",
+  color: 360,
+  description: "Create a specific date and time value. Enter day, month, and year, then attach a Time block to set the time of day. The result is calculated as the date at midnight in the configured timezone, plus the attached time value. Use the settings cog to configure the timezone for the calculation.",
+
+  connections: {
+    mode: "value",
+    output: ["expression", "time"],
+  },
+
+  mutator,
+
+  template: `
+    DateTime |CENTER
+    %DAY / %MONTH / %YEAR at %TIME
+  `,
+
+  fields: {
+    DAY: {
+      description: "Day of the month (1-31). The value will be validated against the selected month.",
+      options: makeOptions({
+        from: 1,
+        upTo: 32,
+        valueFunc: d => d.toString().padStart(2, '0')
+      })
+    },
+    MONTH: {
+      description: "Month of the year.",
+      options: [
+        ['January', '01'],
+        ['February', '02'],
+        ['March', '03'],
+        ['April', '04'],
+        ['May', '05'],
+        ['June', '06'],
+        ['July', '07'],
+        ['August', '08'],
+        ['September', '09'],
+        ['October', '10'],
+        ['November', '11'],
+        ['December', '12'],
+      ]
+    },
+    YEAR: {
+      description: "Year (2020-2035).",
+      options: yearOptions
+    }
+  },
+
+  inputs: {
+    TIME: {
+      description: "The time of day to add to the date. This is added to midnight of the selected date in the configured timezone.",
+      check: ["expression", "time"],
+      shadow: {
+        type: 'io_utility_time',
+        fields: {
+          HOUR: '12',
+          MINUTE: '00'
+        }
+      }
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const 
+        day = block.getFieldValue('DAY'),
+        month = block.getFieldValue('MONTH'),
+        year = block.getFieldValue('YEAR'),
+        time = generator.valueToCode(block, 'TIME', 0) || 'null',
+        timezoneType = block.timezoneType || 'tz_io_account'
+      
+      return [JSON.stringify({
+        datetime: {
+          day: parseInt(day, 10),
+          month: parseInt(month, 10),
+          year: parseInt(year, 10),
+          time: JSON.parse(time),
+          timezone: { type: timezoneType }
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { datetime } = blockObject
+      if (!datetime) {
+        throw new Error("No datetime data for io_utility_datetime regenerator")
+      }
+      
+      const { day, month, year, time, timezone } = datetime
+      
+      return {
+        type: 'io_utility_datetime',
+        fields: {
+          DAY: day.toString().padStart(2, '0'),
+          MONTH: month.toString().padStart(2, '0'),
+          YEAR: year.toString()
+        },
+        inputs: {
+          TIME: helpers.expressionToBlock(time, { 
+            shadow: {
+              type: 'io_utility_time',
+              fields: {
+                HOUR: '12',
+                MINUTE: '00'
+              }
+            }
+          })
+        },
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/datetime/mutator.js
+++ b/app/blocks/utility/datetime/mutator.js
@@ -1,0 +1,41 @@
+/** Single timezone slot mutator for DateTime block */
+export default {
+  timezoneType: 'tz_io_account',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType
+    }
+  },
+
+  loadExtraState: function({ timezoneType }) {
+    this.timezoneType = timezoneType || 'tz_io_account'
+  },
+
+  flyoutBlockTypes: ['tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset'],
+
+  decompose: function(workspace) {
+    // Initialize the top-level block for the sub-diagram
+    const settingsBlock = workspace.newBlock('datetime_tz_settings')
+    settingsBlock.initSvg()
+
+    // Create the timezone block based on saved state
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+
+    // Connect it to the settings block
+    const
+      { connection } = settingsBlock.getInput("TIMEZONE"),
+      { outputConnection } = timezoneBlock
+
+    connection.connect(outputConnection)
+    connection.setShadowState({ type: 'tz_io_account' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+  }
+}

--- a/app/blocks/utility/datetime/timezone_settings.js
+++ b/app/blocks/utility/datetime/timezone_settings.js
@@ -1,0 +1,26 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "datetime_tz_settings",
+  name: "DateTime Timezone Settings",
+  colour: 360,
+  description: "Configure the timezone for the datetime calculation",
+
+  connections: { },
+
+  template: `
+    DateTime Settings |CENTER
+    Timezone: %TIMEZONE
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      description: "The timezone to use when calculating the datetime value",
+      check: 'timezone',
+      shadow: 'tz_io_account',
+    }
+  },
+
+  generators: {
+    json: () => [ {}, 0 ]
+  }
+}

--- a/app/blocks/utility/datetime_to_text.js
+++ b/app/blocks/utility/datetime_to_text.js
@@ -9,7 +9,7 @@ export default {
 
   connections: {
     mode: 'value',
-    output: 'String'
+    output: ['expression', 'string']
   },
 
   mutator,

--- a/app/blocks/utility/datetime_to_text.js
+++ b/app/blocks/utility/datetime_to_text.js
@@ -1,0 +1,61 @@
+import mutator from './datetime_to_text/mutator.js'
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "io_utility_datetime_to_text",
+  name: "Convert to Text",
+  colour: 20,
+  description: "Convert a datetime or seconds value to a formatted text string. Configure timezone and output format (ISO 8601, RFC 2822, custom strftime patterns, etc.) using the settings cog.",
+
+  connections: {
+    mode: 'value',
+    output: 'String'
+  },
+
+  mutator,
+
+  template: "format %INPUT as text",
+
+  inputs: {
+    INPUT: {
+      description: "The datetime or seconds value to format as text",
+      check: ['expression', 'time'],
+      shadow: 'io_utility_current_time'
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const input = generator.valueToCode(block, 'INPUT')
+      return {
+        datetimeToText: {
+          input,
+          timezone: { type: block.timezoneType || 'tz_io_account' },
+          format: { type: block.formatType || 'fmt_iso8601' }
+        }
+      }
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { datetimeToText } = blockObject
+      if (!datetimeToText) {
+        throw new Error("No datetimeToText data for io_utility_datetime_to_text regenerator")
+      }
+      
+      const { input, timezone, format } = datetimeToText
+      
+      return {
+        type: 'io_utility_datetime_to_text',
+        inputs: {
+          INPUT: helpers.expressionToBlock(input, { shadow: 'io_utility_current_time' })
+        },
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account',
+          formatType: format?.type || 'fmt_iso8601'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/datetime_to_text/mutator.js
+++ b/app/blocks/utility/datetime_to_text/mutator.js
@@ -1,0 +1,51 @@
+/** Mutator for datetime_to_text block - timezone and format settings */
+export default {
+  timezoneType: 'tz_io_account',
+  formatType: 'fmt_iso8601',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType,
+      formatType: this.formatType
+    }
+  },
+
+  loadExtraState: function(state) {
+    this.timezoneType = state?.timezoneType || 'tz_io_account'
+    this.formatType = state?.formatType || 'fmt_iso8601'
+  },
+
+  flyoutBlockTypes: [
+    'tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset',
+    'fmt_iso8601', 'fmt_rfc2822', 'fmt_unix', 'fmt_preset', 'fmt_custom'
+  ],
+
+  decompose: function(workspace) {
+    const settingsBlock = workspace.newBlock('datetime_to_text_settings')
+    settingsBlock.initSvg()
+
+    // Create and connect timezone block
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+    const tzInput = settingsBlock.getInput("TIMEZONE")
+    tzInput.connection.connect(timezoneBlock.outputConnection)
+    tzInput.connection.setShadowState({ type: 'tz_io_account' })
+
+    // Create and connect format block
+    const formatBlock = workspace.newBlock(this.formatType)
+    formatBlock.initSvg()
+    const fmtInput = settingsBlock.getInput("FORMAT")
+    fmtInput.connection.connect(formatBlock.outputConnection)
+    fmtInput.connection.setShadowState({ type: 'fmt_iso8601' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    const formatInput = settingsBlock.getInputTargetBlock("FORMAT")
+    
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+    this.formatType = formatInput?.type || 'fmt_iso8601'
+  }
+}

--- a/app/blocks/utility/datetime_to_text/settings.js
+++ b/app/blocks/utility/datetime_to_text/settings.js
@@ -1,0 +1,32 @@
+/** Mutator settings block for datetime_to_text - timezone and format slots */
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "datetime_to_text_settings",
+  name: "DateTime to Text Settings",
+  colour: 20,
+  description: "Settings container for Convert to Text block with timezone and format options.",
+
+  connections: {},
+
+  template: `
+    Settings |CENTER
+    Timezone: %TIMEZONE
+    Format: %FORMAT
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      check: 'timezone',
+      shadow: 'tz_io_account'
+    },
+    FORMAT: {
+      check: 'datetime_format',
+      shadow: 'fmt_iso8601'
+    }
+  },
+
+  generators: {
+    json: () => { }
+  }
+}

--- a/app/blocks/utility/duration.js
+++ b/app/blocks/utility/duration.js
@@ -1,0 +1,95 @@
+import mutator from './duration/mutator.js'
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_duration',
+  bytecodeKey: "duration",
+  name: "Create Duration",
+  color: 360,
+  description: "Create a duration value that can be added to or subtracted from datetime values. Select a unit (seconds, minutes, hours, days, weeks, months, or years) and enter a numeric amount. Use the settings cog to configure timezone for calendar-based units (days, weeks, months, years) which may vary based on daylight saving time. Perfect for calculations like 'sunset - 2 hours' or 'next week'.",
+
+  connections: {
+    mode: "value",
+    output: ["expression", "duration"],
+  },
+
+  mutator,
+
+  template: `
+    Duration: %AMOUNT %UNIT
+  `,
+
+  fields: {
+    UNIT: {
+      description: "The unit of time for the duration.",
+      options: [
+        ['Seconds', 'seconds'],
+        ['Minutes', 'minutes'],
+        ['Hours', 'hours'],
+        ['Days', 'days'],
+        ['Weeks', 'weeks'],
+        ['Months', 'months'],
+        ['Years', 'years'],
+      ]
+    }
+  },
+
+  inputs: {
+    AMOUNT: {
+      description: "The numeric amount for the duration. Can be positive (to add) or negative (to subtract).",
+      check: ["expression", "number"],
+      shadow: {
+        type: 'io_math_number',
+        fields: {
+          NUM: '1'
+        }
+      }
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const 
+        amountCode = generator.valueToCode(block, 'AMOUNT', 0) || '{"number":1}',
+        unit = block.getFieldValue('UNIT'),
+        timezoneType = block.timezoneType || 'tz_io_account'
+      
+      return [JSON.stringify({
+        duration: {
+          amount: JSON.parse(amountCode),
+          unit,
+          timezone: { type: timezoneType }
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { duration } = blockObject
+      if (!duration) {
+        throw new Error("No duration data for io_utility_duration regenerator")
+      }
+      
+      const { amount, unit, timezone } = duration
+      
+      return {
+        type: 'io_utility_duration',
+        fields: {
+          UNIT: unit
+        },
+        inputs: {
+          AMOUNT: helpers.expressionToBlock(amount, { 
+            shadow: {
+              type: 'io_math_number',
+              fields: { NUM: '1' }
+            }
+          })
+        },
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/duration/mutator.js
+++ b/app/blocks/utility/duration/mutator.js
@@ -1,0 +1,41 @@
+/** Single timezone slot mutator for Duration block */
+export default {
+  timezoneType: 'tz_io_account',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType
+    }
+  },
+
+  loadExtraState: function({ timezoneType }) {
+    this.timezoneType = timezoneType || 'tz_io_account'
+  },
+
+  flyoutBlockTypes: ['tz_io_account', 'tz_utc', 'tz_device', 'tz_preset', 'tz_fixed_offset'],
+
+  decompose: function(workspace) {
+    // Initialize the top-level block for the sub-diagram
+    const settingsBlock = workspace.newBlock('duration_tz_settings')
+    settingsBlock.initSvg()
+
+    // Create the timezone block based on saved state
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+
+    // Connect it to the settings block
+    const
+      { connection } = settingsBlock.getInput("TIMEZONE"),
+      { outputConnection } = timezoneBlock
+
+    connection.connect(outputConnection)
+    connection.setShadowState({ type: 'tz_io_account' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+  }
+}

--- a/app/blocks/utility/duration/timezone_settings.js
+++ b/app/blocks/utility/duration/timezone_settings.js
@@ -1,0 +1,26 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "duration_tz_settings",
+  name: "Duration Timezone Settings",
+  colour: 360,
+  description: "Configure the timezone for calendar-based duration calculations (days, weeks, months, years)",
+
+  connections: { },
+
+  template: `
+    Duration Settings |CENTER
+    Timezone: %TIMEZONE
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      description: "The timezone to use for calendar-based duration calculations. This affects how days, weeks, months, and years are calculated around daylight saving time transitions.",
+      check: 'timezone',
+      shadow: 'tz_io_account',
+    }
+  },
+
+  generators: {
+    json: () => [ {}, 0 ]
+  }
+}

--- a/app/blocks/utility/extract_date_segment.js
+++ b/app/blocks/utility/extract_date_segment.js
@@ -1,0 +1,83 @@
+import mutator from './extract_date_segment/mutator.js'
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_extract_date_segment',
+  bytecodeKey: "extractDateSegment",
+  name: "Extract Date Segment",
+  color: 360,
+  description: "Extract a specific date component (year, month, day, or day of week) from a timestamp in seconds. Use the settings cog to configure which timezone the input timestamp should be interpreted in. Perfect for extracting the month or day from a timestamp for date-based conditions.",
+
+  connections: {
+    mode: "value",
+    output: "expression",
+  },
+
+  mutator,
+
+  template: `
+    Extract %SEGMENT |CENTER
+    from %DATE
+  `,
+
+  fields: {
+    SEGMENT: {
+      description: "Which date component to extract from the input timestamp.",
+      options: [
+        ['Year', 'year'],
+        ['Month (1-12)', 'month'],
+        ['Day of Month (1-31)', 'day'],
+        ['Day of Week (0-6, Sun=0)', 'weekday'],
+      ]
+    }
+  },
+
+  inputs: {
+    DATE: {
+      description: "The timestamp value in seconds to extract from. This can come from feed timestamps, datetime blocks, or any expression that evaluates to seconds since epoch.",
+      check: ["expression", "time"],
+      shadow: 'io_utility_current_time'
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const 
+        segment = block.getFieldValue('SEGMENT'),
+        date = generator.valueToCode(block, 'DATE', 0) || 'null',
+        timezoneType = block.timezoneType || 'tz_io_account'
+      
+      return [JSON.stringify({
+        extractDateSegment: {
+          segment,
+          date: JSON.parse(date),
+          timezone: { type: timezoneType }
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { extractDateSegment } = blockObject
+      if (!extractDateSegment) {
+        throw new Error("No extractDateSegment data for io_utility_extract_date_segment regenerator")
+      }
+      
+      const { segment, date, timezone } = extractDateSegment
+      
+      return {
+        type: 'io_utility_extract_date_segment',
+        fields: {
+          SEGMENT: segment
+        },
+        inputs: {
+          DATE: helpers.expressionToBlock(date, { shadow: 'io_utility_current_time' })
+        },
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/extract_date_segment/mutator.js
+++ b/app/blocks/utility/extract_date_segment/mutator.js
@@ -1,0 +1,41 @@
+/** Single timezone slot mutator for Extract Date Segment */
+export default {
+  timezoneType: 'tz_io_account',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType
+    }
+  },
+
+  loadExtraState: function({ timezoneType }) {
+    this.timezoneType = timezoneType || 'tz_io_account'
+  },
+
+  flyoutBlockTypes: ['tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset'],
+
+  decompose: function(workspace) {
+    // Initialize the top-level block for the sub-diagram
+    const settingsBlock = workspace.newBlock('extract_date_timezone_settings')
+    settingsBlock.initSvg()
+
+    // Create the timezone block based on saved state
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+
+    // Connect it to the settings block
+    const
+      { connection } = settingsBlock.getInput("TIMEZONE"),
+      { outputConnection } = timezoneBlock
+
+    connection.connect(outputConnection)
+    connection.setShadowState({ type: 'tz_io_account' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+  }
+}

--- a/app/blocks/utility/extract_date_segment/timezone_settings.js
+++ b/app/blocks/utility/extract_date_segment/timezone_settings.js
@@ -1,0 +1,26 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "extract_date_timezone_settings",
+  name: "Timezone Settings",
+  colour: 360,
+  description: "Configure the timezone for date value interpretation",
+
+  connections: { },
+
+  template: `
+    Timezone Settings |CENTER
+    Input Timezone: %TIMEZONE
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      description: "The timezone to use for interpreting the input date value",
+      check: 'timezone',
+      shadow: 'tz_io_account',
+    }
+  },
+
+  generators: {
+    json: () => [ {}, 0 ]
+  }
+}

--- a/app/blocks/utility/extract_time_segment.js
+++ b/app/blocks/utility/extract_time_segment.js
@@ -1,0 +1,82 @@
+import mutator from './extract_time_segment/mutator.js'
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_extract_time_segment',
+  bytecodeKey: "extractTimeSegment",
+  name: "Extract Time Segment",
+  color: 360,
+  description: "Extract a specific time component (hour, minute, or second) from a time value in seconds. Similar to JSONPath but for time data. Use the settings cog to configure which timezone the input time should be interpreted in. Perfect for extracting just the hour from a timestamp for time-based conditions.",
+
+  connections: {
+    mode: "value",
+    output: "expression",
+  },
+
+  mutator,
+
+  template: `
+    Extract %SEGMENT |CENTER
+    from %TIME
+  `,
+
+  fields: {
+    SEGMENT: {
+      description: "Which time component to extract from the input value.",
+      options: [
+        ['Hour (0-23)', 'hour'],
+        ['Minute (0-59)', 'minute'],
+        ['Second (0-59)', 'second'],
+      ]
+    }
+  },
+
+  inputs: {
+    TIME: {
+      description: "The time value in seconds to extract from. This can come from feed timestamps, the Current Time block, or any expression that evaluates to seconds.",
+      check: ["expression", "time"],
+      shadow: 'io_utility_current_time'
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const 
+        segment = block.getFieldValue('SEGMENT'),
+        time = generator.valueToCode(block, 'TIME', 0) || 'null',
+        timezoneType = block.timezoneType || 'tz_io_account'
+      
+      return [JSON.stringify({
+        extractTimeSegment: {
+          segment,
+          time: JSON.parse(time),
+          timezone: { type: timezoneType }
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { extractTimeSegment } = blockObject
+      if (!extractTimeSegment) {
+        throw new Error("No extractTimeSegment data for io_utility_extract_time_segment regenerator")
+      }
+      
+      const { segment, time, timezone } = extractTimeSegment
+      
+      return {
+        type: 'io_utility_extract_time_segment',
+        fields: {
+          SEGMENT: segment
+        },
+        inputs: {
+          TIME: helpers.expressionToBlock(time, { shadow: 'io_utility_current_time' })
+        },
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/extract_time_segment/mutator.js
+++ b/app/blocks/utility/extract_time_segment/mutator.js
@@ -1,0 +1,41 @@
+/** Single timezone slot mutator for Extract Time Segment */
+export default {
+  timezoneType: 'tz_io_account',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType
+    }
+  },
+
+  loadExtraState: function({ timezoneType }) {
+    this.timezoneType = timezoneType || 'tz_io_account'
+  },
+
+  flyoutBlockTypes: ['tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset'],
+
+  decompose: function(workspace) {
+    // Initialize the top-level block for the sub-diagram
+    const settingsBlock = workspace.newBlock('extract_time_timezone_settings')
+    settingsBlock.initSvg()
+
+    // Create the timezone block based on saved state
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+
+    // Connect it to the settings block
+    const
+      { connection } = settingsBlock.getInput("TIMEZONE"),
+      { outputConnection } = timezoneBlock
+
+    connection.connect(outputConnection)
+    connection.setShadowState({ type: 'tz_io_account' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+  }
+}

--- a/app/blocks/utility/extract_time_segment/timezone_settings.js
+++ b/app/blocks/utility/extract_time_segment/timezone_settings.js
@@ -1,0 +1,26 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "extract_time_timezone_settings",
+  name: "Timezone Settings",
+  colour: 360,
+  description: "Configure the timezone for time value interpretation",
+
+  connections: { },
+
+  template: `
+    Timezone Settings |CENTER
+    Input Timezone: %TIMEZONE
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      description: "The timezone to use for interpreting the input time value",
+      check: 'timezone',
+      shadow: 'tz_io_account',
+    }
+  },
+
+  generators: {
+    json: () => [ {}, 0 ]
+  }
+}

--- a/app/blocks/utility/format/fmt_custom.js
+++ b/app/blocks/utility/format/fmt_custom.js
@@ -1,0 +1,29 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "fmt_custom",
+  name: "Custom Format (strftime)",
+  colour: 20,
+  description: "Custom strftime format string. Use codes like %Y (year), %m (month), %d (day), %H (hour), %M (minute), %S (second), %A (weekday name), %B (month name), etc.",
+
+  connections: {
+    mode: 'value',
+    output: 'datetime_format'
+  },
+
+  template: "Custom: %FORMAT_STRING",
+
+  fields: {
+    FORMAT_STRING: {
+      description: "strftime format string (e.g., %Y-%m-%d %H:%M:%S)",
+      text: "%Y-%m-%d %H:%M:%S"
+    }
+  },
+
+  generators: {
+    json: block => ({ format: { type: 'strftime', pattern: block.getFieldValue('FORMAT_STRING') } })
+  },
+
+  regenerators: {
+    json: ({ format }) => ['fmt_custom', { FORMAT_STRING: format?.pattern || '%Y-%m-%d %H:%M:%S' }]
+  }
+}

--- a/app/blocks/utility/format/fmt_iso8601.js
+++ b/app/blocks/utility/format/fmt_iso8601.js
@@ -1,0 +1,22 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "fmt_iso8601",
+  name: "ISO 8601 Format",
+  colour: 20,
+  description: "ISO 8601 standard format (e.g., 2024-12-25T14:30:00Z). The most widely used format for data interchange.",
+
+  connections: {
+    mode: 'value',
+    output: 'datetime_format'
+  },
+
+  template: "ISO 8601",
+
+  generators: {
+    json: () => ({ format: { type: 'iso8601' } })
+  },
+
+  regenerators: {
+    json: () => ['fmt_iso8601', {}]
+  }
+}

--- a/app/blocks/utility/format/fmt_preset.js
+++ b/app/blocks/utility/format/fmt_preset.js
@@ -1,0 +1,42 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "fmt_preset",
+  name: "Preset Format",
+  colour: 20,
+  description: "Common date/time format presets for easy selection.",
+
+  connections: {
+    mode: 'value',
+    output: 'datetime_format'
+  },
+
+  template: "%FORMAT",
+
+  fields: {
+    FORMAT: {
+      description: "Choose a preset date/time format",
+      options: [
+        ["Date Only (2024-12-25)", "date_iso"],
+        ["Time Only (14:30:00)", "time_iso"],
+        ["Date & Time (2024-12-25 14:30)", "datetime_short"],
+        ["Full Date (December 25, 2024)", "date_long"],
+        ["Full DateTime (December 25, 2024 2:30 PM)", "datetime_long"],
+        ["Short Date (12/25/24)", "date_short_us"],
+        ["European Date (25/12/2024)", "date_short_eu"],
+        ["Year-Month (2024-12)", "year_month"],
+        ["Month-Day (Dec 25)", "month_day"],
+        ["Day of Week (Wednesday)", "day_name"],
+        ["12-Hour Time (2:30 PM)", "time_12h"],
+        ["24-Hour Time (14:30)", "time_24h"]
+      ]
+    }
+  },
+
+  generators: {
+    json: block => ({ format: { type: 'preset', preset: block.getFieldValue('FORMAT') } })
+  },
+
+  regenerators: {
+    json: ({ format }) => ['fmt_preset', { FORMAT: format?.preset || 'datetime_short' }]
+  }
+}

--- a/app/blocks/utility/format/fmt_rfc2822.js
+++ b/app/blocks/utility/format/fmt_rfc2822.js
@@ -1,0 +1,22 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "fmt_rfc2822",
+  name: "RFC 2822 Format",
+  colour: 20,
+  description: "RFC 2822 email date format (e.g., Wed, 25 Dec 2024 14:30:00 +0000). Common in email headers and HTTP.",
+
+  connections: {
+    mode: 'value',
+    output: 'datetime_format'
+  },
+
+  template: "RFC 2822 (Email)",
+
+  generators: {
+    json: () => ({ format: { type: 'rfc2822' } })
+  },
+
+  regenerators: {
+    json: () => ['fmt_rfc2822', {}]
+  }
+}

--- a/app/blocks/utility/format/fmt_unix.js
+++ b/app/blocks/utility/format/fmt_unix.js
@@ -1,0 +1,22 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "fmt_unix",
+  name: "Unix Timestamp Format",
+  colour: 20,
+  description: "Unix timestamp - seconds since January 1, 1970 (e.g., 1735138200). Ideal for calculations and storage.",
+
+  connections: {
+    mode: 'value',
+    output: 'datetime_format'
+  },
+
+  template: "Unix Timestamp",
+
+  generators: {
+    json: () => ({ format: { type: 'unix' } })
+  },
+
+  regenerators: {
+    json: () => ['fmt_unix', {}]
+  }
+}

--- a/app/blocks/utility/text_to_datetime.js
+++ b/app/blocks/utility/text_to_datetime.js
@@ -1,0 +1,64 @@
+import mutator from './text_to_datetime/mutator.js'
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "io_utility_text_to_datetime",
+  name: "Convert from Text",
+  colour: 20,
+  description: "Parse a text string into a datetime value. Configure the expected timezone and input format (ISO 8601, RFC 2822, custom strftime patterns, etc.) using the settings cog.",
+
+  connections: {
+    mode: 'value',
+    output: ['expression', 'time']
+  },
+
+  mutator,
+
+  template: "parse %INPUT as datetime",
+
+  inputs: {
+    INPUT: {
+      description: "The text string to parse as a datetime",
+      check: ['expression', 'string'],
+      shadow: {
+        type: 'io_text',
+        fields: { TEXT: '2024-01-01T12:00:00Z' }
+      }
+    }
+  },
+
+  generators: {
+    json: (block, generator) => {
+      const input = generator.valueToCode(block, 'INPUT')
+      return {
+        textToDatetime: {
+          input,
+          timezone: { type: block.timezoneType || 'tz_io_account' },
+          format: { type: block.formatType || 'fmt_iso8601' }
+        }
+      }
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { textToDatetime } = blockObject
+      if (!textToDatetime) {
+        throw new Error("No textToDatetime data for io_utility_text_to_datetime regenerator")
+      }
+      
+      const { input, timezone, format } = textToDatetime
+      
+      return {
+        type: 'io_utility_text_to_datetime',
+        inputs: {
+          INPUT: helpers.expressionToBlock(input, { shadow: { type: 'io_text', fields: { TEXT: '2024-01-01T12:00:00Z' } } })
+        },
+        extraState: {
+          timezoneType: timezone?.type || 'tz_io_account',
+          formatType: format?.type || 'fmt_iso8601'
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/text_to_datetime/mutator.js
+++ b/app/blocks/utility/text_to_datetime/mutator.js
@@ -1,0 +1,51 @@
+/** Mutator for text_to_datetime block - timezone and format settings */
+export default {
+  timezoneType: 'tz_io_account',
+  formatType: 'fmt_iso8601',
+
+  saveExtraState: function() {
+    return {
+      timezoneType: this.timezoneType,
+      formatType: this.formatType
+    }
+  },
+
+  loadExtraState: function(state) {
+    this.timezoneType = state?.timezoneType || 'tz_io_account'
+    this.formatType = state?.formatType || 'fmt_iso8601'
+  },
+
+  flyoutBlockTypes: [
+    'tz_io_account', 'tz_io_server', 'tz_preset', 'tz_location_coords', 'tz_fixed_offset',
+    'fmt_iso8601', 'fmt_rfc2822', 'fmt_unix', 'fmt_preset', 'fmt_custom'
+  ],
+
+  decompose: function(workspace) {
+    const settingsBlock = workspace.newBlock('text_to_datetime_settings')
+    settingsBlock.initSvg()
+
+    // Create and connect timezone block
+    const timezoneBlock = workspace.newBlock(this.timezoneType)
+    timezoneBlock.initSvg()
+    const tzInput = settingsBlock.getInput("TIMEZONE")
+    tzInput.connection.connect(timezoneBlock.outputConnection)
+    tzInput.connection.setShadowState({ type: 'tz_io_account' })
+
+    // Create and connect format block
+    const formatBlock = workspace.newBlock(this.formatType)
+    formatBlock.initSvg()
+    const fmtInput = settingsBlock.getInput("FORMAT")
+    fmtInput.connection.connect(formatBlock.outputConnection)
+    fmtInput.connection.setShadowState({ type: 'fmt_iso8601' })
+
+    return settingsBlock
+  },
+
+  compose: function(settingsBlock) {
+    const timezoneInput = settingsBlock.getInputTargetBlock("TIMEZONE")
+    const formatInput = settingsBlock.getInputTargetBlock("FORMAT")
+    
+    this.timezoneType = timezoneInput?.type || 'tz_io_account'
+    this.formatType = formatInput?.type || 'fmt_iso8601'
+  }
+}

--- a/app/blocks/utility/text_to_datetime/settings.js
+++ b/app/blocks/utility/text_to_datetime/settings.js
@@ -1,0 +1,32 @@
+/** Mutator settings block for text_to_datetime - timezone and format slots */
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: "text_to_datetime_settings",
+  name: "Text to DateTime Settings",
+  colour: 20,
+  description: "Settings container for Convert from Text block with timezone and format options.",
+
+  connections: {},
+
+  template: `
+    Settings |CENTER
+    Timezone: %TIMEZONE
+    Format: %FORMAT
+  `,
+
+  inputs: {
+    TIMEZONE: {
+      check: 'timezone',
+      shadow: 'tz_io_account'
+    },
+    FORMAT: {
+      check: 'datetime_format',
+      shadow: 'fmt_iso8601'
+    }
+  },
+
+  generators: {
+    json: () => { }
+  }
+}

--- a/app/blocks/utility/time.js
+++ b/app/blocks/utility/time.js
@@ -1,0 +1,67 @@
+import { makeOptions } from "#app/util/fields.js"
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'io_utility_time',
+  name: "Time",
+  color: 360,
+  description: "Create a time value in 24-hour format for use in comparisons and conditions. Perfect for building time-based logic like 'if current time > 14:30' or 'if time equals 09:00'. Hours range from 00-23, minutes from 00-59. The time value can be compared with other times or used in mathematical operations. Found in the Time category alongside Current Time block.",
+  connections: {
+    mode: "value",
+    output: ["expression", "time"],
+  },
+  template: "%HOUR : %MINUTE",
+  fields: {
+    HOUR: {
+      description: "Select the hour in 24-hour format (00-23). Examples: 00 for midnight, 12 for noon, 14 for 2 PM, 23 for 11 PM. This military time format ensures precise time comparisons without AM/PM confusion.",
+      options: makeOptions({ 
+        upTo: 24,
+        valueFunc: hour => hour.toString().padStart(2, '0')
+      })
+    },
+    MINUTE: {
+      description: "Select the minute (00-59). Examples: 00 for on the hour, 15 for quarter past, 30 for half past, 45 for quarter to. Combined with hours, creates precise time values for your automation logic.",
+      options: makeOptions({ 
+        upTo: 60,
+        valueFunc: minute => minute.toString().padStart(2, '0')
+      })
+    }
+  },
+  generators: {
+    json: block => {
+      const 
+        hour = block.getFieldValue('HOUR'),
+        minute = block.getFieldValue('MINUTE'),
+        timeValue = `${hour}:${minute}`,
+        // Convert to minutes since midnight for numeric comparison
+        totalMinutes = parseInt(hour, 10) * 60 + parseInt(minute, 10)
+      
+      return [JSON.stringify({
+        time: {
+          display: timeValue,
+          value: totalMinutes
+        }
+      }), 0]
+    }
+  },
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const timeData = blockObject.time
+      if (!timeData) {
+        throw new Error("No time data for io_utility_time regenerator")
+      }
+      
+      const totalMinutes = timeData.value
+      const hour = Math.floor(totalMinutes / 60).toString().padStart(2, '0')
+      const minute = (totalMinutes % 60).toString().padStart(2, '0')
+      
+      return {
+        type: 'io_utility_time',
+        fields: {
+          HOUR: hour,
+          MINUTE: minute
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/time.js
+++ b/app/blocks/utility/time.js
@@ -34,12 +34,12 @@ export default {
         minute = block.getFieldValue('MINUTE'),
         timeValue = `${hour}:${minute}`,
         // Convert to minutes since midnight for numeric comparison
-        totalMinutes = parseInt(hour, 10) * 60 + parseInt(minute, 10)
+        totalSeconds = (parseInt(hour, 10) * 60 + parseInt(minute, 10)) * 60
       
       return [JSON.stringify({
         time: {
           display: timeValue,
-          value: totalMinutes
+          value: totalSeconds
         }
       }), 0]
     }
@@ -51,9 +51,9 @@ export default {
         throw new Error("No time data for io_utility_time regenerator")
       }
       
-      const totalMinutes = timeData.value
-      const hour = Math.floor(totalMinutes / 60).toString().padStart(2, '0')
-      const minute = (totalMinutes % 60).toString().padStart(2, '0')
+      const totalSeconds = timeData.value
+      const hour = Math.floor(totalSeconds / 3600).toString().padStart(2, '0')
+      const minute = Math.floor((totalSeconds % 3600) / 60).toString().padStart(2, '0')
       
       return {
         type: 'io_utility_time',

--- a/app/blocks/utility/timezone/tz_fixed_offset.js
+++ b/app/blocks/utility/timezone/tz_fixed_offset.js
@@ -1,0 +1,86 @@
+import { makeOptions } from "#app/util/fields.js"
+
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'tz_fixed_offset',
+  name: "Fixed UTC Offset",
+  color: 360,
+  description: "Specify a fixed offset from UTC time. Use this when you need a consistent time offset that doesn't change with daylight saving time. Format: ±HH:MM from UTC.",
+
+  connections: {
+    mode: "value",
+    output: "timezone",
+  },
+
+  template: "Fixed UTC Offset %SIGN %HOURS : %MINUTES",
+
+  fields: {
+    SIGN: {
+      description: "Direction of offset from UTC. '+' means ahead of UTC (east), '-' means behind UTC (west).",
+      options: [
+        ['+', '+'],
+        ['-', '-'],
+      ]
+    },
+    HOURS: {
+      description: "Hours offset from UTC (0-14). Examples: 0 for UTC, 1 for Central European Time, 5 for Eastern Standard Time offset.",
+      options: makeOptions({
+        upTo: 15,
+        valueFunc: h => h.toString().padStart(2, '0')
+      })
+    },
+    MINUTES: {
+      description: "Minutes offset from UTC (0-59). Most timezones use 00, but some use 30 or 45 minute offsets.",
+      options: [
+        ['00', '00'],
+        ['15', '15'],
+        ['30', '30'],
+        ['45', '45'],
+      ]
+    }
+  },
+
+  generators: {
+    json: (block) => {
+      const 
+        sign = block.getFieldValue('SIGN'),
+        hours = parseInt(block.getFieldValue('HOURS'), 10) || 0,
+        minutes = parseInt(block.getFieldValue('MINUTES'), 10) || 0,
+        // Convert to total minutes offset, negative if behind UTC
+        totalMinutes = (sign === '-' ? -1 : 1) * (hours * 60 + minutes)
+      
+      return [JSON.stringify({
+        timezone: {
+          type: 'offset',
+          offsetMinutes: totalMinutes,
+          display: `${sign}${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { timezone } = blockObject
+      if (!timezone || timezone.type !== 'offset') {
+        throw new Error("No offset timezone data for tz_fixed_offset regenerator")
+      }
+      
+      const 
+        totalMinutes = timezone.offsetMinutes,
+        sign = totalMinutes >= 0 ? '+' : '-',
+        absMinutes = Math.abs(totalMinutes),
+        hours = Math.floor(absMinutes / 60).toString().padStart(2, '0'),
+        minutes = (absMinutes % 60).toString().padStart(2, '0')
+      
+      return {
+        type: 'tz_fixed_offset',
+        fields: {
+          SIGN: sign,
+          HOURS: hours,
+          MINUTES: minutes
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/timezone/tz_io_account.js
+++ b/app/blocks/utility/timezone/tz_io_account.js
@@ -1,0 +1,36 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'tz_io_account',
+  name: "IO Account Timezone",
+  color: 360,
+  description: "Use your Adafruit IO account's configured timezone. This automatically adjusts for daylight saving time based on your account settings (e.g., Europe/London, America/New_York). This is the default timezone for user-derived time values.",
+
+  connections: {
+    mode: "value",
+    output: "timezone",
+  },
+
+  template: "IO Account Timezone",
+
+  generators: {
+    json: () => {
+      return [JSON.stringify({
+        timezone: {
+          type: 'account'
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      if (!blockObject.timezone || blockObject.timezone.type !== 'account') {
+        throw new Error("No account timezone data for tz_io_account regenerator")
+      }
+      
+      return {
+        type: 'tz_io_account'
+      }
+    }
+  }
+}

--- a/app/blocks/utility/timezone/tz_io_server.js
+++ b/app/blocks/utility/timezone/tz_io_server.js
@@ -1,0 +1,37 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'tz_io_server',
+  name: "IO Server Time",
+  color: 360,
+  description: "Use Adafruit IO server time (Eastern Standard Time / EST). This is the default timezone for feed properties like 'updated_at' and other template-related timestamp values.",
+
+  connections: {
+    mode: "value",
+    output: "timezone",
+  },
+
+  template: "IO Server Time (EST)",
+
+  generators: {
+    json: () => {
+      return [JSON.stringify({
+        timezone: {
+          type: 'server',
+          iana: 'America/New_York'
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      if (!blockObject.timezone || blockObject.timezone.type !== 'server') {
+        throw new Error("No server timezone data for tz_io_server regenerator")
+      }
+      
+      return {
+        type: 'tz_io_server'
+      }
+    }
+  }
+}

--- a/app/blocks/utility/timezone/tz_location_coords.js
+++ b/app/blocks/utility/timezone/tz_location_coords.js
@@ -1,0 +1,58 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'tz_location_coords',
+  name: "Timezone by Coordinates",
+  color: 360,
+  description: "Determine timezone based on geographic coordinates (latitude and longitude). Useful for location-aware IoT devices that need to calculate local time based on their physical position.",
+
+  connections: {
+    mode: "value",
+    output: "timezone",
+  },
+
+  template: "Location: Lat: %LAT Long: %LONG",
+
+  fields: {
+    LAT: {
+      description: "Latitude coordinate (-90 to 90). Positive values are North, negative values are South. Example: 51.5074 for London, 40.7128 for New York.",
+      text: '0'
+    },
+    LONG: {
+      description: "Longitude coordinate (-180 to 180). Positive values are East, negative values are West. Example: -0.1278 for London, -74.0060 for New York.",
+      text: '0'
+    }
+  },
+
+  generators: {
+    json: (block) => {
+      const 
+        lat = parseFloat(block.getFieldValue('LAT')) || 0,
+        long = parseFloat(block.getFieldValue('LONG')) || 0
+      
+      return [JSON.stringify({
+        timezone: {
+          type: 'coordinates',
+          lat,
+          long
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { timezone } = blockObject
+      if (!timezone || timezone.type !== 'coordinates') {
+        throw new Error("No coordinates timezone data for tz_location_coords regenerator")
+      }
+      
+      return {
+        type: 'tz_location_coords',
+        fields: {
+          LAT: timezone.lat.toString(),
+          LONG: timezone.long.toString()
+        }
+      }
+    }
+  }
+}

--- a/app/blocks/utility/timezone/tz_preset.js
+++ b/app/blocks/utility/timezone/tz_preset.js
@@ -1,0 +1,55 @@
+/** @type {import('#types').BlockDefinitionRaw} */
+export default {
+  type: 'tz_preset',
+  name: "Timezone Preset",
+  color: 360,
+  description: "Select from common timezone presets including UTC, Europe/London, America/New_York, and America/Los_Angeles (Pacific). These automatically handle daylight saving time adjustments.",
+
+  connections: {
+    mode: "value",
+    output: "timezone",
+  },
+
+  template: "Timezone: %TIMEZONE",
+
+  fields: {
+    TIMEZONE: {
+      description: "Select a timezone from the preset list. UTC is the universal coordinated time with no daylight saving. Other options adjust automatically for their regional daylight saving rules.",
+      options: [
+        ['UTC', 'UTC'],
+        ['Europe/London', 'Europe/London'],
+        ['America/New York', 'America/New_York'],
+        ['America/Los Angeles (Pacific)', 'America/Los_Angeles'],
+      ]
+    }
+  },
+
+  generators: {
+    json: (block) => {
+      const timezone = block.getFieldValue('TIMEZONE')
+      
+      return [JSON.stringify({
+        timezone: {
+          type: 'iana',
+          iana: timezone
+        }
+      }), 0]
+    }
+  },
+
+  regenerators: {
+    json: (blockObject, helpers) => {
+      const { timezone } = blockObject
+      if (!timezone || timezone.type !== 'iana') {
+        throw new Error("No IANA timezone data for tz_preset regenerator")
+      }
+      
+      return {
+        type: 'tz_preset',
+        fields: {
+          TIMEZONE: timezone.iana
+        }
+      }
+    }
+  }
+}

--- a/app/toolbox/index.js
+++ b/app/toolbox/index.js
@@ -4,6 +4,7 @@ import Math from './math.js'
 import Notifications from './notifications.js'
 import Weather from './weather.js'
 import Text from './text.js'
+import Time from './time.js'
 import Triggers from './triggers.js'
 import Utility from './utility.js'
 import Variables from './variables.js'
@@ -15,6 +16,7 @@ export default [
   Logic,
   Math,
   Text,
+  Time,
   Variables,
   Feeds,
   Notifications,

--- a/app/toolbox/time.js
+++ b/app/toolbox/time.js
@@ -1,0 +1,8 @@
+export default {
+  name: 'Time',
+  colour: 360,
+  contents: [
+    'io_utility_time',
+    'io_utility_current_time'
+  ]
+}

--- a/app/toolbox/time.js
+++ b/app/toolbox/time.js
@@ -5,6 +5,7 @@ export default {
     'io_utility_time',
     'io_utility_current_time',
     'io_utility_datetime',
+    'io_utility_duration',
     'io_utility_extract_time_segment',
     'io_utility_extract_date_segment',
     'io_utility_convert_seconds_datetime',

--- a/app/toolbox/time.js
+++ b/app/toolbox/time.js
@@ -3,6 +3,12 @@ export default {
   colour: 360,
   contents: [
     'io_utility_time',
-    'io_utility_current_time'
+    'io_utility_current_time',
+    'io_utility_datetime',
+    'io_utility_extract_time_segment',
+    'io_utility_extract_date_segment',
+    'io_utility_convert_seconds_datetime',
+    'io_utility_datetime_to_text',
+    'io_utility_text_to_datetime',
   ]
 }

--- a/dev_server.js
+++ b/dev_server.js
@@ -8,7 +8,12 @@ const execAsync = promisify(exec)
 
 // run a clean documentation build, wait for it to complete
 console.log("Building docs from scratch...")
-spawnSync("node", ["export.js", "docs"], { stdio: 'inherit', shell: true })
+const buildResult = spawnSync("node", ["export.js", "docs"], { stdio: 'inherit', shell: true })
+if(buildResult.status !== 0) {
+  // we should probably just run them here if necessary
+  console.log("\n⚠️  Initial docs build failed (see error above)")
+  console.log("⚠️  The dev server will still start, but you may need to run: npm run export:block-images\n")
+}
 
 // start the file watcher and incremental builder
 console.log("Starting incremental builder and file watcher...")

--- a/export.js
+++ b/export.js
@@ -101,21 +101,22 @@ const
 
       // extract the screenshots
       console.log('Generating screenshots...')
+      const browser = process.platform === 'win32' ? 'chrome' : 'chromium'
       await spawnSync("npx", ["cypress", "run",
         "--config", `downloadsFolder=${imageDestination}`,
         "--config-file", `cypress/cypress.config.js`,
-        "--browser", "chromium",
+        "--browser", browser,
         "--spec", "cypress/e2e/block_images.cy.js",
       ], { stdio: 'inherit', shell: true })
       console.log('Generation complete.')
 
       // kill the server
-      if(!viteProcess.kill()) {
-        console.log("Vite failed to exit gracefully")
-        process.exit(1)
+      try {
+        viteProcess.kill('SIGTERM')
+        console.log('Server closed.')
+      } catch (err) {
+        console.log("Vite process already closed")
       }
-
-      console.log('Server closed.')
     }
   },
   exporterNames = Object.keys(exporters)

--- a/package-lock.json
+++ b/package-lock.json
@@ -178,6 +178,7 @@
       "integrity": "sha512-EJJ7WmvmUXZdchueKFCK8UZFyLqy4Hz64snNp0cTc7c0MKaSeDGYEDxVsIJKp15r7ORaoGxSyS4y6BGZMXYuCg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.27.0",
         "@algolia/requester-browser-xhr": "5.27.0",
@@ -1041,74 +1042,12 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1909,6 +1848,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1972,6 +1912,7 @@
       "integrity": "sha512-2PvAgvxxJzA3+dB+ERfS2JPdvUsxNf89Cc2GF5iCcFupTULOwmbfinvqrC4Qj9nHJJDNf494NqEN/1f9177ZTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.27.0",
         "@algolia/client-analytics": "5.27.0",
@@ -2218,6 +2159,7 @@
       "resolved": "https://registry.npmjs.org/blockly/-/blockly-10.4.3.tgz",
       "integrity": "sha512-+opfBmQnSiv7vTiY/TkDEBOslxUyfj8luS3S+qs1NnQKjInC+Waf2l9cNsMh9J8BMkmiCIT+Ed/3mmjIaL9wug==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsdom": "22.1.0"
       }
@@ -2273,14 +2215,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/cachedir": {
       "version": "2.4.0",
@@ -2937,6 +2871,7 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -3059,6 +2994,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3454,6 +3390,7 @@
       "integrity": "sha512-7Ke1jyybbbPZyZXFxEftUtxFGLMpE2n6A+z//m4CRDlj0hW+o3iYSmh8nFlYMurOiJVDmJRilUQtJr08KfIxlg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -5057,6 +4994,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5631,17 +5569,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5650,18 +5577,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/space-separated-tokens": {
@@ -5874,34 +5789,6 @@
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/terser": {
-      "version": "5.19.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.3.tgz",
-      "integrity": "sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -6240,6 +6127,7 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6847,6 +6735,7 @@
       "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.16",
         "@vue/compiler-sfc": "3.5.16",

--- a/src/docs/render_block_inputs.js
+++ b/src/docs/render_block_inputs.js
@@ -65,7 +65,7 @@ const
         if (compatibleBlocks.length) {
           lines.push('::: details Compatible Blocks   (click to expand)')
           const blockCards = compatibleBlocks.map(blockDef => {
-            const cleanLink = blockDef.documentationPath().replace(/\.md$/i, '');
+            const cleanLink = blockDef.documentationPath().replace(/\.md$/i, '.html');
             const
               imgSrc = `/block_images/${blockDef.type}.png`,
               altText = `the ${blockDef.name} block`,

--- a/src/exporters/block_index_exporter.js
+++ b/src/exporters/block_index_exporter.js
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'fs'
+import { writeFileSync, mkdirSync } from 'fs'
 import { isString, without } from 'lodash-es'
 
 import { renderBlockImage } from '../docs/render_block.js'
@@ -80,7 +80,10 @@ editLink: false
       ? options.toFile
       : `index.md`
 
-    writeFileSync(`${this.destination}/${filename}`, finalMarkdown)
+    const fullPath = `${this.destination}/${filename}`
+    const dirName = fullPath.split("/").slice(0, -1).join("/")
+    mkdirSync(dirName, { recursive: true })
+    writeFileSync(fullPath, finalMarkdown)
   }
 
   exportToFile = (toFile=true) => {

--- a/test/app/blocks/snapshots/block_snapshots_test.js.snapshot
+++ b/test/app/blocks/snapshots/block_snapshots_test.js.snapshot
@@ -3,7 +3,7 @@ exports[`Block Snapshots > Blockly JSON > action_email 1`] = `
   "inputsInline": false,
   "type": "action_email",
   "colour": "0",
-  "tooltip": "Sends an email with given subject and body templates",
+  "tooltip": "Sends an email with given subject and body templates.",
   "nextStatement": "expression",
   "previousStatement": "expression",
   "message0": "📧 Email %1",
@@ -61,7 +61,7 @@ exports[`Block Snapshots > Blockly JSON > action_root 1`] = `
   "inputsInline": false,
   "type": "action_root",
   "colour": "0",
-  "tooltip": "The foundation of every Adafruit IO Action. Connect Triggers (like 'when temperature > 80°F' or 'every morning at 8 AM') to define when your Action runs, then attach Action blocks (like 'send email', 'publish to feed', or 'if/then logic') to define what happens when triggered.",
+  "tooltip": "The foundation of every Adafruit IO Action.",
   "message0": "Triggers: %1",
   "args0": [
     {
@@ -94,7 +94,7 @@ exports[`Block Snapshots > Blockly JSON > action_root 1`] = `
       "align": "RIGHT"
     }
   ],
-  "message4": "ㅤ %1",
+  "message4": "  %1",
   "args4": [
     {
       "type": "input_dummy",
@@ -264,7 +264,7 @@ exports[`Block Snapshots > Blockly JSON > day_settings 1`] = `
   "inputsInline": false,
   "type": "day_settings",
   "colour": 30,
-  "tooltip": "How would you like to specify days of the month for your schedule?",
+  "tooltip": "How would you like to specify days of the month for your schedule?.",
   "message0": "Day: %1",
   "args0": [
     {
@@ -344,7 +344,7 @@ exports[`Block Snapshots > Blockly JSON > delay_days 1`] = `
   "inputsInline": false,
   "type": "delay_days",
   "colour": "0",
-  "tooltip": "1 day is the maximum delay available",
+  "tooltip": "1 day is the maximum delay available.",
   "output": "delay_period",
   "message0": "1 day %1",
   "args0": [
@@ -362,7 +362,7 @@ exports[`Block Snapshots > Blockly JSON > delay_hours 1`] = `
   "inputsInline": false,
   "type": "delay_hours",
   "colour": "0",
-  "tooltip": "Set a delay between 1 and 23 hours",
+  "tooltip": "Set a delay between 1 and 23 hours.",
   "output": "delay_period",
   "message0": "%1 hours %2",
   "args0": [
@@ -478,7 +478,7 @@ exports[`Block Snapshots > Blockly JSON > delay_minutes 1`] = `
   "inputsInline": false,
   "type": "delay_minutes",
   "colour": "0",
-  "tooltip": "Set a delay between 1 and 59 minutes",
+  "tooltip": "Set a delay between 1 and 59 minutes.",
   "output": "delay_period",
   "message0": "%1 minutes %2",
   "args0": [
@@ -756,7 +756,7 @@ exports[`Block Snapshots > Blockly JSON > delay_seconds 1`] = `
   "inputsInline": false,
   "type": "delay_seconds",
   "colour": "0",
-  "tooltip": "Set a delay between 1 and 59 seconds (or 0 for no delay)",
+  "tooltip": "Set a delay between 1 and 59 seconds (or 0 for no delay).",
   "output": "delay_period",
   "message0": "%1 seconds %2",
   "args0": [
@@ -1016,7 +1016,7 @@ exports[`Block Snapshots > Blockly JSON > delay_settings 1`] = `
   "inputsInline": false,
   "type": "delay_settings",
   "colour": "0",
-  "tooltip": "Causes a delay between this Action's trigger and its execution",
+  "tooltip": "Causes a delay between this Action's trigger and its execution.",
   "message0": "Delay Settings %1",
   "args0": [
     {
@@ -2354,7 +2354,7 @@ exports[`Block Snapshots > Blockly JSON > feed_get_value 1`] = `
   "inputsInline": false,
   "type": "feed_get_value",
   "colour": 300,
-  "tooltip": "Resolves to the last value of this feed or component, always a String",
+  "tooltip": "Resolves to the last value of this feed or component, always a String.",
   "output": "expression",
   "message0": "Get %1 %2",
   "args0": [
@@ -2421,7 +2421,7 @@ exports[`Block Snapshots > Blockly JSON > hour_settings 1`] = `
   "inputsInline": false,
   "type": "hour_settings",
   "colour": 30,
-  "tooltip": "How would you like to specify hours of the day for your schedule?",
+  "tooltip": "How would you like to specify hours of the day for your schedule?.",
   "message0": "Hour: %1",
   "args0": [
     {
@@ -2440,7 +2440,7 @@ exports[`Block Snapshots > Blockly JSON > io_controls_if 1`] = `
   "inputsInline": false,
   "type": "io_controls_if",
   "colour": 60,
-  "tooltip": "Execute different block diagrams based on the outcome of conditional checks.",
+  "tooltip": "Create smart decision-making logic for your IoT Actions using if/then/else statements.",
   "nextStatement": "expression",
   "previousStatement": "expression",
   "message0": "if %1",
@@ -2487,7 +2487,7 @@ exports[`Block Snapshots > Blockly JSON > io_logic_boolean 1`] = `
   "inputsInline": false,
   "type": "io_logic_boolean",
   "colour": 60,
-  "tooltip": "A true or false value.",
+  "tooltip": "A simple true or false value for building logic conditions and controlling digital outputs.",
   "output": [
     "expression",
     "boolean"
@@ -2522,7 +2522,7 @@ exports[`Block Snapshots > Blockly JSON > io_logic_compare 1`] = `
   "inputsInline": true,
   "type": "io_logic_compare",
   "colour": 120,
-  "tooltip": "Build mathematical conditions by comparing any two numerical values in your Action logic. Perfect for creating if/then statements like 'if temperature is greater than target temp', 'if battery level equals low threshold', or 'if sensor reading is between two values'. Works with feed data, variables, calculations, or any numerical inputs.",
+  "tooltip": "Build mathematical conditions by comparing any two numerical values in your Action logic.",
   "output": "expression",
   "message0": "%1",
   "args0": [
@@ -2581,7 +2581,7 @@ exports[`Block Snapshots > Blockly JSON > io_logic_negate 1`] = `
   "inputsInline": false,
   "type": "io_logic_negate",
   "colour": 60,
-  "tooltip": "Flip any condition to its opposite - turns true into false and false into true. Essential for creating inverse logic like 'if NOT raining', 'if door is NOT open', or 'if temperature is NOT above 75°F'. Perfect for building exception handling, safety conditions, and reverse automation logic in your IoT Actions.",
+  "tooltip": "Flip any condition to its opposite - turns true into false and false into true.",
   "output": "expression",
   "message0": "not %1",
   "args0": [
@@ -2601,7 +2601,7 @@ exports[`Block Snapshots > Blockly JSON > io_logic_operation 1`] = `
   "inputsInline": true,
   "type": "io_logic_operation",
   "colour": 60,
-  "tooltip": "Combine multiple conditions to create sophisticated decision logic in your Actions. Perfect for complex automation like 'if temperature is high AND humidity is low', 'if motion detected OR door opened', or any scenario where you need multiple criteria to work together. Essential for building smart, multi-factor IoT control systems.",
+  "tooltip": "Combine multiple conditions to create sophisticated decision logic in your Actions.",
   "output": "expression",
   "message0": "%1",
   "args0": [
@@ -2644,7 +2644,7 @@ exports[`Block Snapshots > Blockly JSON > io_math_arithmetic 1`] = `
   "inputsInline": true,
   "type": "io_math_arithmetic",
   "colour": 120,
-  "tooltip": "Perform the specified arithmetic operation on two specified operands.",
+  "tooltip": "Perform mathematical calculations using sensor data, feed values, or any numbers in your Actions.",
   "output": "expression",
   "message0": "%1",
   "args0": [
@@ -2699,8 +2699,11 @@ exports[`Block Snapshots > Blockly JSON > io_math_constrain 1`] = `
   "inputsInline": false,
   "type": "io_math_constrain",
   "colour": 120,
-  "tooltip": "Constrain a given number to fall within a given range.",
-  "output": "number",
+  "tooltip": "Keep any number within specified minimum and maximum boundaries.",
+  "output": [
+    "expression",
+    "number"
+  ],
   "message0": "Constrain %1",
   "args0": [
     {
@@ -2728,7 +2731,7 @@ exports[`Block Snapshots > Blockly JSON > io_math_number 1`] = `
   "inputsInline": false,
   "type": "io_math_number",
   "colour": 120,
-  "tooltip": "A numeric value, whole or decimal.",
+  "tooltip": "Enter any numerical value for use in your IoT Actions - whole numbers, decimals, positive, or negative.",
   "output": [
     "expression",
     "number"
@@ -2757,7 +2760,7 @@ exports[`Block Snapshots > Blockly JSON > io_math_round 1`] = `
   "inputsInline": false,
   "type": "io_math_round",
   "colour": 120,
-  "tooltip": "Round a value to the nearest whole number via round, floor, or ceiling functions",
+  "tooltip": "Convert decimal numbers to whole numbers using different rounding strategies.",
   "output": "expression",
   "message0": "%1 %2",
   "args0": [
@@ -2795,7 +2798,7 @@ exports[`Block Snapshots > Blockly JSON > io_text 1`] = `
   "inputsInline": false,
   "type": "io_text",
   "colour": 180,
-  "tooltip": "A String of text",
+  "tooltip": "Enter any text content for use in your Actions - words, phrases, device commands, or messages.",
   "output": [
     "expression",
     "string"
@@ -2850,7 +2853,7 @@ exports[`Block Snapshots > Blockly JSON > io_text_multiline 1`] = `
   "inputsInline": false,
   "type": "io_text_multiline",
   "colour": 180,
-  "tooltip": "A String of longer-form text with newlines.",
+  "tooltip": "Create formatted text content with multiple lines, paragraphs, and line breaks.",
   "output": [
     "expression",
     "string"
@@ -2871,12 +2874,402 @@ exports[`Block Snapshots > Blockly JSON > io_text_multiline 1`] = `
 }
 `;
 
+exports[`Block Snapshots > Blockly JSON > io_utility_current_time 1`] = `
+{
+  "inputsInline": false,
+  "type": "io_utility_current_time",
+  "colour": 360,
+  "tooltip": "Get the current system time in 24-hour format for use in time comparisons and conditions.",
+  "output": [
+    "expression",
+    "time"
+  ],
+  "message0": "Current Time %1",
+  "args0": [
+    {
+      "type": "input_dummy",
+      "align": "RIGHT"
+    }
+  ],
+  "helpUrl": "https://io.adafruit.com/actions-docs/blocks/time/current_time"
+}
+`;
+
+exports[`Block Snapshots > Blockly JSON > io_utility_time 1`] = `
+{
+  "inputsInline": false,
+  "type": "io_utility_time",
+  "colour": 360,
+  "tooltip": "Create a time value in 24-hour format for use in comparisons and conditions.",
+  "output": [
+    "expression",
+    "time"
+  ],
+  "message0": "%1 : %2 %3",
+  "args0": [
+    {
+      "name": "HOUR",
+      "type": "field_dropdown",
+      "options": [
+        [
+          "0",
+          "00"
+        ],
+        [
+          "1",
+          "01"
+        ],
+        [
+          "2",
+          "02"
+        ],
+        [
+          "3",
+          "03"
+        ],
+        [
+          "4",
+          "04"
+        ],
+        [
+          "5",
+          "05"
+        ],
+        [
+          "6",
+          "06"
+        ],
+        [
+          "7",
+          "07"
+        ],
+        [
+          "8",
+          "08"
+        ],
+        [
+          "9",
+          "09"
+        ],
+        [
+          "10",
+          "10"
+        ],
+        [
+          "11",
+          "11"
+        ],
+        [
+          "12",
+          "12"
+        ],
+        [
+          "13",
+          "13"
+        ],
+        [
+          "14",
+          "14"
+        ],
+        [
+          "15",
+          "15"
+        ],
+        [
+          "16",
+          "16"
+        ],
+        [
+          "17",
+          "17"
+        ],
+        [
+          "18",
+          "18"
+        ],
+        [
+          "19",
+          "19"
+        ],
+        [
+          "20",
+          "20"
+        ],
+        [
+          "21",
+          "21"
+        ],
+        [
+          "22",
+          "22"
+        ],
+        [
+          "23",
+          "23"
+        ]
+      ]
+    },
+    {
+      "name": "MINUTE",
+      "type": "field_dropdown",
+      "options": [
+        [
+          "0",
+          "00"
+        ],
+        [
+          "1",
+          "01"
+        ],
+        [
+          "2",
+          "02"
+        ],
+        [
+          "3",
+          "03"
+        ],
+        [
+          "4",
+          "04"
+        ],
+        [
+          "5",
+          "05"
+        ],
+        [
+          "6",
+          "06"
+        ],
+        [
+          "7",
+          "07"
+        ],
+        [
+          "8",
+          "08"
+        ],
+        [
+          "9",
+          "09"
+        ],
+        [
+          "10",
+          "10"
+        ],
+        [
+          "11",
+          "11"
+        ],
+        [
+          "12",
+          "12"
+        ],
+        [
+          "13",
+          "13"
+        ],
+        [
+          "14",
+          "14"
+        ],
+        [
+          "15",
+          "15"
+        ],
+        [
+          "16",
+          "16"
+        ],
+        [
+          "17",
+          "17"
+        ],
+        [
+          "18",
+          "18"
+        ],
+        [
+          "19",
+          "19"
+        ],
+        [
+          "20",
+          "20"
+        ],
+        [
+          "21",
+          "21"
+        ],
+        [
+          "22",
+          "22"
+        ],
+        [
+          "23",
+          "23"
+        ],
+        [
+          "24",
+          "24"
+        ],
+        [
+          "25",
+          "25"
+        ],
+        [
+          "26",
+          "26"
+        ],
+        [
+          "27",
+          "27"
+        ],
+        [
+          "28",
+          "28"
+        ],
+        [
+          "29",
+          "29"
+        ],
+        [
+          "30",
+          "30"
+        ],
+        [
+          "31",
+          "31"
+        ],
+        [
+          "32",
+          "32"
+        ],
+        [
+          "33",
+          "33"
+        ],
+        [
+          "34",
+          "34"
+        ],
+        [
+          "35",
+          "35"
+        ],
+        [
+          "36",
+          "36"
+        ],
+        [
+          "37",
+          "37"
+        ],
+        [
+          "38",
+          "38"
+        ],
+        [
+          "39",
+          "39"
+        ],
+        [
+          "40",
+          "40"
+        ],
+        [
+          "41",
+          "41"
+        ],
+        [
+          "42",
+          "42"
+        ],
+        [
+          "43",
+          "43"
+        ],
+        [
+          "44",
+          "44"
+        ],
+        [
+          "45",
+          "45"
+        ],
+        [
+          "46",
+          "46"
+        ],
+        [
+          "47",
+          "47"
+        ],
+        [
+          "48",
+          "48"
+        ],
+        [
+          "49",
+          "49"
+        ],
+        [
+          "50",
+          "50"
+        ],
+        [
+          "51",
+          "51"
+        ],
+        [
+          "52",
+          "52"
+        ],
+        [
+          "53",
+          "53"
+        ],
+        [
+          "54",
+          "54"
+        ],
+        [
+          "55",
+          "55"
+        ],
+        [
+          "56",
+          "56"
+        ],
+        [
+          "57",
+          "57"
+        ],
+        [
+          "58",
+          "58"
+        ],
+        [
+          "59",
+          "59"
+        ]
+      ]
+    },
+    {
+      "type": "input_dummy",
+      "align": "RIGHT"
+    }
+  ],
+  "helpUrl": "https://io.adafruit.com/actions-docs/blocks/time/time"
+}
+`;
+
 exports[`Block Snapshots > Blockly JSON > io_variables_get 1`] = `
 {
   "inputsInline": false,
   "type": "io_variables_get",
   "colour": 240,
-  "tooltip": "Retrieve the value stored in a variable that was previously set using a Set Variable block. Use this to access stored feed values, calculation results, or any data saved earlier in your Action.",
+  "tooltip": "Retrieve the value stored in a variable that was previously set using a Set Variable block.",
   "output": "expression",
   "message0": "Get variable %1 %2",
   "args0": [
@@ -2898,7 +3291,7 @@ exports[`Block Snapshots > Blockly JSON > io_variables_set 1`] = `
   "inputsInline": true,
   "type": "io_variables_set",
   "colour": 240,
-  "tooltip": "Store a value in a named variable for later use in your Action. Variables let you remember feed values, calculation results, or any data to use in subsequent action blocks.",
+  "tooltip": "Store a value in a named variable for later use in your Action.",
   "nextStatement": "expression",
   "previousStatement": "expression",
   "message0": "Set variable %1 = %2",
@@ -2923,7 +3316,7 @@ exports[`Block Snapshots > Blockly JSON > matcher_compare 1`] = `
   "inputsInline": true,
   "type": "matcher_compare",
   "colour": 224,
-  "tooltip": "Create smart triggers based on numerical sensor data and thresholds. Perfect for temperature alerts ('notify when above 80°F'), battery monitoring ('warn when below 20%'), humidity control ('turn on fan when over 60%'), or any sensor-based automation that depends on numerical comparisons.",
+  "tooltip": "Create smart triggers based on numerical sensor data and thresholds.",
   "output": "matcher",
   "message0": "%1 %2",
   "args0": [
@@ -2973,7 +3366,7 @@ exports[`Block Snapshots > Blockly JSON > matcher_text_compare 1`] = `
   "inputsInline": true,
   "type": "matcher_text_compare",
   "colour": 180,
-  "tooltip": "Compare text-based feed data using smart text matching. Perfect for triggers based on status messages ('door opened', 'motion detected'), device states ('online', 'offline'), or any text-based sensor data. Works with exact matches, exclusions, or partial text detection within longer messages.",
+  "tooltip": "Compare text-based feed data using smart text matching.",
   "output": "matcher",
   "message0": "%1 %2",
   "args0": [
@@ -3011,8 +3404,11 @@ exports[`Block Snapshots > Blockly JSON > math_map 1`] = `
   "inputsInline": false,
   "type": "math_map",
   "colour": 120,
-  "tooltip": "Scale a value from one range of numbers to another",
-  "output": "number",
+  "tooltip": "Transform sensor readings and data values by scaling them from one number range to another.",
+  "output": [
+    "expression",
+    "number"
+  ],
   "message0": "Map %1",
   "args0": [
     {
@@ -3092,7 +3488,7 @@ exports[`Block Snapshots > Blockly JSON > minute_settings 1`] = `
   "inputsInline": false,
   "type": "minute_settings",
   "colour": 30,
-  "tooltip": "How would you like to specify minutes of the hour for your schedule?",
+  "tooltip": "How would you like to specify minutes of the hour for your schedule?.",
   "message0": "Minute: %1",
   "args0": [
     {
@@ -3111,7 +3507,7 @@ exports[`Block Snapshots > Blockly JSON > month_settings 1`] = `
   "inputsInline": false,
   "type": "month_settings",
   "colour": 30,
-  "tooltip": "How would you like to specify the months portion of your schedule?",
+  "tooltip": "How would you like to specify the months portion of your schedule?.",
   "message0": "Month: %1",
   "args0": [
     {
@@ -3130,7 +3526,7 @@ exports[`Block Snapshots > Blockly JSON > on_schedule 1`] = `
   "inputsInline": false,
   "type": "on_schedule",
   "colour": 30,
-  "tooltip": "Create powerful time-based automation that runs your Actions on a schedule - from simple daily reminders to complex patterns like 'every 15 minutes during weekdays' or 'first Monday of each quarter'. Works like a smart alarm clock for your IoT devices, automatically triggering actions without any manual intervention. Perfect for turning lights on/off, sending regular reports, or controlling devices based on time patterns.",
+  "tooltip": "Create powerful time-based automation that runs your Actions on a schedule - from simple daily reminders to complex patterns like 'every 15 minutes during weekdays' or 'first Monday of each quarter'.",
   "nextStatement": "trigger",
   "previousStatement": "trigger",
   "message0": "Schedule %1",
@@ -3886,7 +4282,7 @@ exports[`Block Snapshots > Blockly JSON > text_compare 1`] = `
   "inputsInline": true,
   "type": "text_compare",
   "colour": 180,
-  "tooltip": "Compare any two pieces of text or data to build conditional logic in your Actions. Perfect for creating if/then statements like 'if device status equals online', 'if user name is not guest', or 'if error message contains timeout'. Works with feed values, variables, user input, or any text-based data.",
+  "tooltip": "Compare any two pieces of text or data to build conditional logic in your Actions.",
   "output": "expression",
   "message0": "%1",
   "args0": [
@@ -3933,7 +4329,7 @@ exports[`Block Snapshots > Blockly JSON > text_template 1`] = `
   "inputsInline": true,
   "type": "text_template",
   "colour": 180,
-  "tooltip": "Render a text template.",
+  "tooltip": "Create dynamic, personalized messages by combining static text with live data from your IoT system.",
   "output": [
     "expression",
     "string"
@@ -4109,7 +4505,7 @@ exports[`Block Snapshots > Blockly JSON > when_data 1`] = `
   "inputsInline": true,
   "type": "when_data",
   "colour": 30,
-  "tooltip": "The simplest trigger - runs your Action every single time ANY new data arrives at a feed, regardless of what the value is. Perfect for logging all activity ('record every sensor reading'), acknowledging data receipt ('send confirmation for every message'), or triggering workflows that need to process all incoming data. No conditions, no filtering - just pure data arrival detection.",
+  "tooltip": "The simplest trigger - runs your Action every single time ANY new data arrives at a feed, regardless of what the value is.",
   "nextStatement": "trigger",
   "previousStatement": "trigger",
   "message0": "When %1 gets any data %2",
@@ -4142,7 +4538,7 @@ exports[`Block Snapshots > Blockly JSON > when_data_matching 1`] = `
   "inputsInline": true,
   "type": "when_data_matching",
   "colour": 30,
-  "tooltip": "The most common trigger type - runs your Action immediately whenever new data arrives at a feed that meets your specified condition. Perfect for real-time responses like 'send alert when temperature exceeds 85°F', 'turn on lights when motion detected', or 'notify me when battery drops below 20%'. This trigger fires every single time the condition is met.",
+  "tooltip": "The most common trigger type - runs your Action immediately whenever new data arrives at a feed that meets your specified condition.",
   "nextStatement": "trigger",
   "previousStatement": "trigger",
   "message0": "When %1 gets data matching: %2",
@@ -4177,7 +4573,7 @@ exports[`Block Snapshots > Blockly JSON > when_data_matching_state 1`] = `
   "inputsInline": true,
   "type": "when_data_matching_state",
   "colour": 30,
-  "tooltip": "Advanced trigger that watches for changes in how your feed data matches a condition over time. Unlike basic triggers that just check if data equals a value, this compares the current data point with the previous one to detect when conditions START being true, STOP being true, or CONTINUE being true. Perfect for detecting state changes like 'temperature just went above 80°' or 'door just closed after being open'.",
+  "tooltip": "Advanced trigger that watches for changes in how your feed data matches a condition over time.",
   "nextStatement": "trigger",
   "previousStatement": "trigger",
   "message0": "When %1 gets data that %2 matching %3",

--- a/test/app/blocks/utility_current_time_block_test.js
+++ b/test/app/blocks/utility_current_time_block_test.js
@@ -1,0 +1,84 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import currentTimeBlockDefObject from "#app/blocks/utility/current_time.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Utility Current Time Block", () => {
+  it("works", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    assert.equal(currentTimeDefinition.type, 'io_utility_current_time')
+  })
+
+  it("exports block JSON", () => {
+    const
+      currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject),
+      currentTimeBlockJSON = currentTimeDefinition.toBlocklyJSON()
+
+    // contains message and args
+    assert.exists(currentTimeBlockJSON.message0)
+    assert.exists(currentTimeBlockJSON.args0)
+
+    // has proper output types
+    assert.deepEqual(currentTimeBlockJSON.output, ['expression', 'time'])
+
+    // has correct color
+    assert.equal(currentTimeBlockJSON.colour, 360)
+  })
+
+  it("exports instance JSON with correct type", () => {
+    const
+      currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject),
+      currentTimeInstanceJson = currentTimeDefinition.toBlocklyInstanceJSON()
+
+    // has correct type
+    assert.equal(currentTimeInstanceJson.type, 'io_utility_current_time')
+
+    // no fields needed for current time block
+    assert.notExists(currentTimeInstanceJson.fields)
+  })
+
+  it("generates correct JSON output", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    const [result, precedence] = currentTimeDefinition.generators.json()
+    const parsedResult = JSON.parse(result)
+
+    assert.equal(precedence, 0)
+    assert.exists(parsedResult.currentTime)
+    assert.isObject(parsedResult.currentTime)
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    const blockObject = {
+      currentTime: {}
+    }
+
+    const regenerated = currentTimeDefinition.regenerators.json(blockObject)
+
+    assert.equal(regenerated.type, 'io_utility_current_time')
+    assert.notExists(regenerated.fields) // No fields needed
+  })
+
+  it("throws error when regenerating without currentTime data", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    const blockObject = {}
+
+    assert.throws(() => {
+      currentTimeDefinition.regenerators.json(blockObject)
+    }, Error, "No currentTime data for io_utility_current_time regenerator")
+  })
+
+  it("has compatible output type with time blocks", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    // Should have same output types as regular time blocks for compatibility
+    const outputTypes = currentTimeDefinition.connections.output
+    assert.includeMembers(outputTypes, ['expression', 'time'])
+  })
+})

--- a/test/app/blocks/utility_current_time_block_test.js
+++ b/test/app/blocks/utility_current_time_block_test.js
@@ -43,12 +43,18 @@ describe("Utility Current Time Block", () => {
   it("generates correct JSON output", () => {
     const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
 
-    const [result, precedence] = currentTimeDefinition.generators.json()
+    // Generator now expects a block object with timezoneType
+    const mockBlock = {
+      timezoneType: 'tz_io_account'
+    }
+    
+    const [result, precedence] = currentTimeDefinition.generators.json(mockBlock)
     const parsedResult = JSON.parse(result)
 
     assert.equal(precedence, 0)
     assert.exists(parsedResult.currentTime)
     assert.isObject(parsedResult.currentTime)
+    assert.deepEqual(parsedResult.currentTime.timezone, { type: 'tz_io_account' })
   })
 
   it("regenerates correctly from JSON", () => {
@@ -80,5 +86,72 @@ describe("Utility Current Time Block", () => {
     // Should have same output types as regular time blocks for compatibility
     const outputTypes = currentTimeDefinition.connections.output
     assert.includeMembers(outputTypes, ['expression', 'time'])
+  })
+
+  it("has mutator for timezone configuration", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+    
+    assert.exists(currentTimeDefinition.mutator, 'should have a mutator for timezone settings')
+  })
+
+  it("generates JSON with different timezone types", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+    
+    const timezones = [
+      { type: 'tz_io_account', description: 'IO Account timezone (default)' },
+      { type: 'tz_utc', description: 'UTC timezone' },
+      { type: 'tz_device', description: 'Device timezone' },
+    ]
+    
+    for (const tz of timezones) {
+      const mockBlock = { timezoneType: tz.type }
+      const [result] = currentTimeDefinition.generators.json(mockBlock)
+      const parsed = JSON.parse(result)
+      
+      assert.deepEqual(parsed.currentTime.timezone, { type: tz.type }, 
+        `Should generate correct timezone for ${tz.description}`)
+    }
+  })
+
+  it("defaults to tz_io_account when timezoneType is not set", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+    
+    // Mock block without timezoneType set
+    const mockBlock = {}
+    const [result] = currentTimeDefinition.generators.json(mockBlock)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.currentTime.timezone, { type: 'tz_io_account' },
+      'Should default to IO Account timezone')
+  })
+
+  it("regenerates with timezone from JSON", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+    
+    const blockObject = {
+      currentTime: {
+        timezone: { type: 'tz_utc' }
+      }
+    }
+    
+    const regenerated = currentTimeDefinition.regenerators.json(blockObject)
+    
+    assert.equal(regenerated.type, 'io_utility_current_time')
+    assert.exists(regenerated.extraState)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_utc')
+  })
+
+  it("regenerates with default timezone when not specified in JSON", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+    
+    const blockObject = {
+      currentTime: {}
+    }
+    
+    const regenerated = currentTimeDefinition.regenerators.json(blockObject)
+    
+    assert.equal(regenerated.type, 'io_utility_current_time')
+    assert.exists(regenerated.extraState)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_io_account')
   })
 })

--- a/test/app/blocks/utility_datetime_block_test.js
+++ b/test/app/blocks/utility_datetime_block_test.js
@@ -1,0 +1,573 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import datetimeDef from "#app/blocks/utility/datetime.js"
+import timeBlockDef from "#app/blocks/utility/time.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("DateTime Block", () => {
+  it("works", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    assert.equal(definition.type, 'io_utility_datetime')
+  })
+
+  it("exports block JSON with correct structure", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const blockJSON = definition.toBlocklyJSON()
+
+    assert.exists(blockJSON.message0)
+    assert.exists(blockJSON.args0)
+    assert.deepEqual(blockJSON.output, ['expression', 'time'])
+    assert.equal(blockJSON.colour, 360)
+  })
+
+  it("has DAY dropdown with 1-31 options", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    // Block uses multiple messages, so check all args arrays
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const dayArg = allArgs.find(arg => arg.name === 'DAY')
+    assert.exists(dayArg, 'DAY field should exist')
+    assert.equal(dayArg.type, 'field_dropdown')
+    
+    const optionValues = dayArg.options.map(opt => opt[1])
+    assert.include(optionValues, '01')
+    assert.include(optionValues, '14')
+    assert.include(optionValues, '31')
+    assert.equal(optionValues.length, 31)
+  })
+
+  it("has MONTH dropdown with all 12 months", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const monthArg = allArgs.find(arg => arg.name === 'MONTH')
+    assert.exists(monthArg, 'MONTH field should exist')
+    assert.equal(monthArg.type, 'field_dropdown')
+    
+    const optionValues = monthArg.options.map(opt => opt[1])
+    assert.equal(optionValues.length, 12)
+    assert.include(optionValues, '01') // January
+    assert.include(optionValues, '10') // October
+    assert.include(optionValues, '12') // December
+  })
+
+  it("has YEAR dropdown with range 2020-2035", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const yearArg = allArgs.find(arg => arg.name === 'YEAR')
+    assert.exists(yearArg, 'YEAR field should exist')
+    assert.equal(yearArg.type, 'field_dropdown')
+    
+    const optionValues = yearArg.options.map(opt => opt[1])
+    assert.include(optionValues, '2020')
+    assert.include(optionValues, '2024')
+    assert.include(optionValues, '2035')
+  })
+
+  it("has TIME input that accepts time blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const timeArg = allArgs.find(arg => arg.name === 'TIME')
+    assert.exists(timeArg, 'TIME input should exist')
+    assert.equal(timeArg.type, 'input_value')
+    assert.deepEqual(timeArg.check, ['expression', 'time'])
+  })
+
+  it("generates correct JSON for a specific date and time", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'DAY') return '25'
+        if (field === 'MONTH') return '12'
+        if (field === 'YEAR') return '2024'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ time: { display: '00:00', value: 0 } })
+    }
+    
+    const [result, precedence] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.equal(precedence, 0)
+    assert.exists(parsed.datetime)
+    assert.equal(parsed.datetime.day, 25)
+    assert.equal(parsed.datetime.month, 12)
+    assert.equal(parsed.datetime.year, 2024)
+    assert.deepEqual(parsed.datetime.time, { time: { display: '00:00', value: 0 } })
+    assert.deepEqual(parsed.datetime.timezone, { type: 'tz_io_account' })
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    
+    const blockObject = {
+      datetime: {
+        day: 4,
+        month: 7,
+        year: 2024,
+        time: { time: { display: '12:00', value: 43200 } },
+        timezone: { type: 'tz_utc' }
+      }
+    }
+    
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ block: { type: 'io_utility_time' } })
+    }
+    
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+    
+    assert.equal(regenerated.type, 'io_utility_datetime')
+    assert.equal(regenerated.fields.DAY, '04')
+    assert.equal(regenerated.fields.MONTH, '07')
+    assert.equal(regenerated.fields.YEAR, '2024')
+    assert.exists(regenerated.inputs.TIME)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_utc')
+  })
+
+  it("throws error when regenerating without datetime data", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    
+    assert.throws(() => {
+      definition.regenerators.json({}, {})
+    }, /No datetime data/)
+  })
+
+  it("has mutator for timezone configuration", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    assert.exists(definition.mutator, 'should have a mutator')
+  })
+
+  it("output type is compatible with extract block inputs", () => {
+    const datetimeDefinition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDef)
+    
+    const datetimeJSON = datetimeDefinition.toBlocklyJSON()
+    const timeJSON = timeDefinition.toBlocklyJSON()
+    
+    // DateTime outputs ['expression', 'time']
+    assert.deepEqual(datetimeJSON.output, ['expression', 'time'])
+    
+    // Time block also outputs ['expression', 'time']
+    assert.deepEqual(timeJSON.output, ['expression', 'time'])
+  })
+})
+
+
+describe("DateTime Block - Battle of Hastings (October 14, 1066)", () => {
+  // The Battle of Hastings was fought on October 14, 1066
+  // While 1066 is outside the year dropdown range (2020-2035), we can test
+  // the concept of representing historical dates through the block structure
+  
+  it("can represent modern dates that anniversary the Battle of Hastings", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    
+    // October 14, 2024 - 958 years after the battle
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'DAY') return '14'
+        if (field === 'MONTH') return '10'
+        if (field === 'YEAR') return '2024'
+        return null
+      },
+      timezoneType: 'tz_utc'
+    }
+    
+    // Battle reportedly started around 9:00 AM
+    const battleStartTime = { time: { display: '09:00', value: 32400 } }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify(battleStartTime)
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.equal(parsed.datetime.day, 14)
+    assert.equal(parsed.datetime.month, 10)
+    assert.equal(parsed.datetime.year, 2024)
+    // 9:00 AM = 9 * 60 * 60 = 32400 seconds
+    assert.equal(parsed.datetime.time.time.value, 32400)
+  })
+
+  it("regenerates the Battle of Hastings anniversary correctly", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+    
+    const blockObject = {
+      datetime: {
+        day: 14,
+        month: 10,
+        year: 2024,
+        time: { time: { display: '09:00', value: 32400 } },
+        timezone: { type: 'tz_utc' }
+      }
+    }
+    
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ 
+        block: { 
+          type: 'io_utility_time',
+          fields: { HOUR: '09', MINUTE: '00' }
+        } 
+      })
+    }
+    
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+    
+    assert.equal(regenerated.fields.DAY, '14')
+    assert.equal(regenerated.fields.MONTH, '10')
+    assert.equal(regenerated.fields.YEAR, '2024')
+  })
+})
+
+
+describe("DateTime and Time Block Integration", () => {
+  it("Time block output type matches DateTime block TIME input check", () => {
+    const datetimeDefinition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDef)
+    
+    const datetimeJSON = datetimeDefinition.toBlocklyJSON()
+    const timeJSON = timeDefinition.toBlocklyJSON()
+    
+    // Find the TIME input check on datetime block (may be in args1 due to multi-line template)
+    const allArgs = [...(datetimeJSON.args0 || []), ...(datetimeJSON.args1 || [])]
+    const timeInput = allArgs.find(arg => arg.name === 'TIME')
+    
+    // Time block output should be compatible with datetime TIME input
+    // Time outputs ['expression', 'time'], TIME input checks ['expression', 'time']
+    assert.deepEqual(timeJSON.output, ['expression', 'time'])
+    assert.deepEqual(timeInput.check, ['expression', 'time'])
+    
+    // They should match - time block can connect to datetime's TIME input
+    const hasMatchingType = timeJSON.output.some(t => timeInput.check.includes(t))
+    assert.isTrue(hasMatchingType, 'Time block output should be compatible with DateTime TIME input')
+  })
+
+  it("generates combined datetime with numeric time value", () => {
+    const datetimeDefinition = BlockDefinition.parseRawDefinition(datetimeDef)
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDef)
+    
+    // Generate time block output (2:30 PM)
+    const mockTimeBlock = {
+      getFieldValue: (field) => {
+        if (field === 'HOUR') return '14'
+        if (field === 'MINUTE') return '30'
+        return null
+      }
+    }
+    const [timeResult] = timeDefinition.generators.json(mockTimeBlock)
+    const timeValue = JSON.parse(timeResult)
+    
+    // Verify time block output
+    assert.equal(timeValue.time.display, '14:30')
+    assert.equal(timeValue.time.value, 870 * 60) // 14*60 + 30 = 870 minutes = 52200 seconds
+    
+    // Now use that time in a datetime block
+    const mockDatetimeBlock = {
+      getFieldValue: (field) => {
+        if (field === 'DAY') return '14'
+        if (field === 'MONTH') return '10'
+        if (field === 'YEAR') return '2024'
+        return null
+      },
+      timezoneType: 'tz_utc'
+    }
+    const mockGenerator = {
+      valueToCode: () => timeResult
+    }
+    
+    const [datetimeResult] = datetimeDefinition.generators.json(mockDatetimeBlock, mockGenerator)
+    const datetimeValue = JSON.parse(datetimeResult)
+    
+    // Combined datetime should have date components and nested time
+    assert.equal(datetimeValue.datetime.day, 14)
+    assert.equal(datetimeValue.datetime.month, 10)
+    assert.equal(datetimeValue.datetime.year, 2024)
+    assert.equal(datetimeValue.datetime.time.time.value, 52200)
+  })
+})
+
+
+describe("DateTime Block - Historical and Future Dates", () => {
+  // Test various significant dates including outside the dropdown range
+  // to verify the JSON structure works correctly
+  
+  describe("The Millennium (January 1, 2000)", () => {
+    it("can represent Y2K midnight moment via regeneration", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // Y2K: January 1, 2000 at 00:00:00 UTC
+      // While 2000 is outside dropdown (2020-2035), regeneration should handle it
+      const blockObject = {
+        datetime: {
+          day: 1,
+          month: 1,
+          year: 2000,
+          time: { time: { display: '00:00', value: 0 } },
+          timezone: { type: 'tz_utc' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '00', MINUTE: '00' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      // Fields will be padded strings
+      assert.equal(regenerated.fields.DAY, '01')
+      assert.equal(regenerated.fields.MONTH, '01')
+      assert.equal(regenerated.fields.YEAR, '2000')
+      assert.equal(regenerated.extraState.timezoneType, 'tz_utc')
+    })
+
+    it("generates correct JSON for millennium party time (23:59 on Dec 31, 1999)", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // The moment before Y2K - December 31, 1999 at 23:59
+      const mockBlock = {
+        getFieldValue: (field) => {
+          if (field === 'DAY') return '31'
+          if (field === 'MONTH') return '12'
+          if (field === 'YEAR') return '2024' // Using in-range year, structure is same
+          return null
+        },
+        timezoneType: 'tz_utc'
+      }
+      
+      // 23:59 = 23*60*60 + 59*60 = 86340 seconds
+      const partyTime = { time: { display: '23:59', value: 86340 } }
+      const mockGenerator = {
+        valueToCode: () => JSON.stringify(partyTime)
+      }
+      
+      const [result] = definition.generators.json(mockBlock, mockGenerator)
+      const parsed = JSON.parse(result)
+      
+      assert.equal(parsed.datetime.day, 31)
+      assert.equal(parsed.datetime.month, 12)
+      assert.equal(parsed.datetime.time.time.value, 86340)
+    })
+  })
+
+  describe("Year 2038 Problem (January 19, 2038)", () => {
+    // The Y2038 problem affects 32-bit Unix timestamps
+    // Unix time overflow occurs at 03:14:07 UTC on January 19, 2038
+    
+    it("can represent the Unix epoch overflow moment", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      const blockObject = {
+        datetime: {
+          day: 19,
+          month: 1,
+          year: 2038,
+          time: { time: { display: '03:14', value: 11640 } }, // 3*60*60 + 14*60 = 11640 seconds
+          timezone: { type: 'tz_utc' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '03', MINUTE: '14' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      assert.equal(regenerated.fields.DAY, '19')
+      assert.equal(regenerated.fields.MONTH, '01')
+      assert.equal(regenerated.fields.YEAR, '2038')
+    })
+  })
+
+  describe("Year 2039 - Post Y2038", () => {
+    it("can represent dates after the 32-bit epoch overflow", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // A date safely past Y2038: July 4, 2039
+      const blockObject = {
+        datetime: {
+          day: 4,
+          month: 7,
+          year: 2039,
+          time: { time: { display: '12:00', value: 43200 } },
+          timezone: { type: 'tz_io_account' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '12', MINUTE: '00' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      assert.equal(regenerated.fields.DAY, '04')
+      assert.equal(regenerated.fields.MONTH, '07')
+      assert.equal(regenerated.fields.YEAR, '2039')
+    })
+  })
+
+  describe("Year 2050 - Mid-Century", () => {
+    it("can represent mid-century dates", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // January 1, 2050 - start of mid-century
+      const blockObject = {
+        datetime: {
+          day: 1,
+          month: 1,
+          year: 2050,
+          time: { time: { display: '00:00', value: 0 } },
+          timezone: { type: 'tz_utc' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '00', MINUTE: '00' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      assert.equal(regenerated.fields.DAY, '01')
+      assert.equal(regenerated.fields.MONTH, '01')
+      assert.equal(regenerated.fields.YEAR, '2050')
+    })
+
+    it("handles summer solstice 2050", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // June 21, 2050 at solar noon (approximately 12:00 UTC)
+      const blockObject = {
+        datetime: {
+          day: 21,
+          month: 6,
+          year: 2050,
+          time: { time: { display: '12:00', value: 43200 } },
+          timezone: { type: 'tz_utc' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '12', MINUTE: '00' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      assert.equal(regenerated.fields.DAY, '21')
+      assert.equal(regenerated.fields.MONTH, '06')
+      assert.equal(regenerated.fields.YEAR, '2050')
+    })
+  })
+
+  describe("Year 2070 - Far Future", () => {
+    it("can represent far future dates", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // December 31, 2070 at 23:59 - end of 2070
+      const blockObject = {
+        datetime: {
+          day: 31,
+          month: 12,
+          year: 2070,
+          time: { time: { display: '23:59', value: 86340 } },
+          timezone: { type: 'tz_io_account' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '23', MINUTE: '59' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      assert.equal(regenerated.fields.DAY, '31')
+      assert.equal(regenerated.fields.MONTH, '12')
+      assert.equal(regenerated.fields.YEAR, '2070')
+    })
+
+    it("handles centennial of moon landing (July 20, 2069)", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // July 20, 2069 - 100 years after Apollo 11 landing
+      // Armstrong stepped on moon at 02:56 UTC
+      const blockObject = {
+        datetime: {
+          day: 20,
+          month: 7,
+          year: 2069,
+          time: { time: { display: '02:56', value: 10560 } }, // 2*60*60 + 56*60 = 10560
+          timezone: { type: 'tz_utc' }
+        }
+      }
+      
+      const mockHelpers = {
+        expressionToBlock: (expr, opts) => ({ 
+          block: { type: 'io_utility_time', fields: { HOUR: '02', MINUTE: '56' } }
+        })
+      }
+      
+      const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+      
+      assert.equal(regenerated.fields.DAY, '20')
+      assert.equal(regenerated.fields.MONTH, '07')
+      assert.equal(regenerated.fields.YEAR, '2069')
+    })
+  })
+
+  describe("Time value calculations across all dates", () => {
+    it("time values are consistent regardless of date", () => {
+      const definition = BlockDefinition.parseRawDefinition(datetimeDef)
+      
+      // Same time (14:30) should have same value regardless of date
+      const time1430 = { time: { display: '14:30', value: 52200 } } // 14*60*60 + 30*60
+      const mockGenerator = {
+        valueToCode: () => JSON.stringify(time1430)
+      }
+      
+      const dates = [
+        { day: '14', month: '10', year: '2024', name: 'Battle of Hastings anniversary 2024' },
+        { day: '01', month: '01', year: '2020', name: 'Start of 2020' },
+        { day: '31', month: '12', year: '2035', name: 'End of dropdown range' },
+      ]
+      
+      for (const date of dates) {
+        const mockBlock = {
+          getFieldValue: (field) => {
+            if (field === 'DAY') return date.day
+            if (field === 'MONTH') return date.month
+            if (field === 'YEAR') return date.year
+            return null
+          },
+          timezoneType: 'tz_utc'
+        }
+        
+        const [result] = definition.generators.json(mockBlock, mockGenerator)
+        const parsed = JSON.parse(result)
+        
+        assert.equal(parsed.datetime.time.time.value, 52200, 
+          `Time value should be 52200 for ${date.name}`)
+      }
+    })
+  })
+})

--- a/test/app/blocks/utility_datetime_to_text_block_test.js
+++ b/test/app/blocks/utility_datetime_to_text_block_test.js
@@ -21,8 +21,8 @@ describe("Utility DateTime to Text Block", () => {
     assert.exists(blockJSON.message0)
     assert.exists(blockJSON.args0)
 
-    // has proper output type - outputs String for text formatting
-    assert.equal(blockJSON.output, 'String')
+    // has proper output type - outputs expression+string for text formatting
+    assert.deepEqual(blockJSON.output, ['expression', 'string'])
 
     // has correct color
     assert.equal(blockJSON.colour, 20)
@@ -121,5 +121,16 @@ describe("Utility DateTime to Text Block", () => {
     // Should include format option blocks
     assert.include(definition.mutator.flyoutBlockTypes, 'fmt_iso8601')
     assert.include(definition.mutator.flyoutBlockTypes, 'fmt_custom')
+  })
+
+  it("output type is compatible with log block input", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    // Log block checks for 'expression', and this block outputs ['expression', 'string']
+    // so it should be connectable to log blocks
+    assert.isArray(blockJSON.output)
+    assert.include(blockJSON.output, 'expression', 'should include expression for log block compatibility')
+    assert.include(blockJSON.output, 'string', 'should include string for text operations')
   })
 })

--- a/test/app/blocks/utility_datetime_to_text_block_test.js
+++ b/test/app/blocks/utility_datetime_to_text_block_test.js
@@ -1,0 +1,125 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import datetimeToTextBlockDefObject from "#app/blocks/utility/datetime_to_text.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Utility DateTime to Text Block", () => {
+  it("works", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+
+    assert.equal(definition.type, 'io_utility_datetime_to_text')
+  })
+
+  it("exports block JSON", () => {
+    const
+      definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject),
+      blockJSON = definition.toBlocklyJSON()
+
+    // contains message and args
+    assert.exists(blockJSON.message0)
+    assert.exists(blockJSON.args0)
+
+    // has proper output type - outputs String for text formatting
+    assert.equal(blockJSON.output, 'String')
+
+    // has correct color
+    assert.equal(blockJSON.colour, 20)
+    
+    // has mutator defined
+    assert.exists(blockJSON.mutator)
+  })
+
+  it("exports instance JSON with correct type", () => {
+    const
+      definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject),
+      instanceJson = definition.toBlocklyInstanceJSON()
+
+    // has correct type
+    assert.equal(instanceJson.type, 'io_utility_datetime_to_text')
+  })
+
+  it("has INPUT that accepts time blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+
+    // Should accept expression and time types (what time blocks output)
+    assert.deepEqual(definition.inputs.INPUT.check, ['expression', 'time'])
+    
+    // Should have a shadow block
+    assert.equal(definition.inputs.INPUT.shadow, 'io_utility_current_time')
+  })
+
+  it("generates correct JSON output", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+
+    // Mock block object with mutator state
+    const mockBlock = {
+      timezoneType: 'tz_preset',
+      formatType: 'fmt_iso8601'
+    }
+
+    // Mock generator
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ currentTime: {} })
+    }
+
+    const result = definition.generators.json(mockBlock, mockGenerator)
+
+    assert.exists(result.datetimeToText)
+    assert.exists(result.datetimeToText.timezone)
+    assert.equal(result.datetimeToText.timezone.type, 'tz_preset')
+    assert.exists(result.datetimeToText.format)
+    assert.equal(result.datetimeToText.format.type, 'fmt_iso8601')
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+
+    const blockObject = {
+      datetimeToText: {
+        input: { currentTime: {} },
+        timezone: { type: 'tz_io_account' },
+        format: { type: 'fmt_rfc2822' }
+      }
+    }
+
+    // Mock helpers
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ block: { type: opts.shadow } })
+    }
+
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+
+    assert.equal(regenerated.type, 'io_utility_datetime_to_text')
+    assert.exists(regenerated.extraState)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_io_account')
+    assert.equal(regenerated.extraState.formatType, 'fmt_rfc2822')
+  })
+
+  it("throws error when regenerating without datetimeToText data", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+
+    const blockObject = {}
+    const mockHelpers = { expressionToBlock: () => ({}) }
+
+    assert.throws(() => {
+      definition.regenerators.json(blockObject, mockHelpers)
+    }, Error, "No datetimeToText data for io_utility_datetime_to_text regenerator")
+  })
+
+  it("has mutator with timezone and format flyout blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(datetimeToTextBlockDefObject)
+
+    assert.exists(definition.mutator)
+    assert.exists(definition.mutator.flyoutBlockTypes)
+    
+    // Should include timezone option blocks
+    assert.include(definition.mutator.flyoutBlockTypes, 'tz_io_account')
+    assert.include(definition.mutator.flyoutBlockTypes, 'tz_preset')
+    
+    // Should include format option blocks
+    assert.include(definition.mutator.flyoutBlockTypes, 'fmt_iso8601')
+    assert.include(definition.mutator.flyoutBlockTypes, 'fmt_custom')
+  })
+})

--- a/test/app/blocks/utility_duration_block_test.js
+++ b/test/app/blocks/utility_duration_block_test.js
@@ -1,0 +1,286 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import durationDef from "#app/blocks/utility/duration.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Duration Block", () => {
+  it("works", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    assert.equal(definition.type, 'io_utility_duration')
+  })
+
+  it("exports block JSON with correct structure", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    const blockJSON = definition.toBlocklyJSON()
+
+    assert.exists(blockJSON.message0)
+    assert.exists(blockJSON.args0)
+    assert.deepEqual(blockJSON.output, ['expression', 'duration'])
+    assert.equal(blockJSON.colour, 360)
+  })
+
+  it("has AMOUNT input that accepts number blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    const amountArg = blockJSON.args0.find(arg => arg.name === 'AMOUNT')
+    assert.exists(amountArg, 'AMOUNT input should exist')
+    assert.equal(amountArg.type, 'input_value')
+    assert.deepEqual(amountArg.check, ['expression', 'number'])
+  })
+
+  it("has UNIT dropdown with all time units", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    // UNIT may be in args1 due to template line breaks
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const unitArg = allArgs.find(arg => arg.name === 'UNIT')
+    assert.exists(unitArg, 'UNIT field should exist')
+    assert.equal(unitArg.type, 'field_dropdown')
+    
+    const optionValues = unitArg.options.map(opt => opt[1])
+    assert.include(optionValues, 'seconds')
+    assert.include(optionValues, 'minutes')
+    assert.include(optionValues, 'hours')
+    assert.include(optionValues, 'days')
+    assert.include(optionValues, 'weeks')
+    assert.include(optionValues, 'months')
+    assert.include(optionValues, 'years')
+    assert.equal(optionValues.length, 7)
+  })
+
+  it("generates correct JSON for a duration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'hours'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: 2 })
+    }
+    
+    const [result, precedence] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.equal(precedence, 0)
+    assert.exists(parsed.duration)
+    assert.deepEqual(parsed.duration.amount, { number: 2 })
+    assert.equal(parsed.duration.unit, 'hours')
+    assert.deepEqual(parsed.duration.timezone, { type: 'tz_io_account' })
+  })
+
+  it("generates correct JSON for negative durations", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    // Negative duration for "2 hours ago" or "sunset - 2 hours"
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'hours'
+        return null
+      },
+      timezoneType: 'tz_utc'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: -2 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { number: -2 })
+    assert.equal(parsed.duration.unit, 'hours')
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const blockObject = {
+      duration: {
+        amount: { number: 7 },
+        unit: 'days',
+        timezone: { type: 'tz_utc' }
+      }
+    }
+    
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ block: { type: 'io_math_number' } })
+    }
+    
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+    
+    assert.equal(regenerated.type, 'io_utility_duration')
+    assert.equal(regenerated.fields.UNIT, 'days')
+    assert.exists(regenerated.inputs.AMOUNT)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_utc')
+  })
+
+  it("throws error when regenerating without duration data", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    assert.throws(() => {
+      definition.regenerators.json({}, {})
+    }, /No duration data/)
+  })
+
+  it("has mutator for timezone configuration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    assert.exists(definition.mutator, 'should have a mutator for timezone settings')
+  })
+
+  it("defaults to tz_io_account when timezoneType is not set", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'days'
+        return null
+      }
+      // timezoneType not set
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: 1 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.timezone, { type: 'tz_io_account' })
+  })
+})
+
+
+describe("Duration Block - Practical Use Cases", () => {
+  it("can represent 'sunset minus 2 hours' duration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'hours'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: -2 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { number: -2 })
+    assert.equal(parsed.duration.unit, 'hours')
+  })
+
+  it("can represent 'next week' duration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'weeks'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: 1 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { number: 1 })
+    assert.equal(parsed.duration.unit, 'weeks')
+  })
+
+  it("can represent '30 days from now' duration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'days'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: 30 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { number: 30 })
+    assert.equal(parsed.duration.unit, 'days')
+  })
+
+  it("can represent '1 year anniversary' duration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'years'
+        return null
+      },
+      timezoneType: 'tz_utc'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: 1 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { number: 1 })
+    assert.equal(parsed.duration.unit, 'years')
+  })
+
+  it("can represent '90 seconds' fine-grained duration", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'seconds'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ number: 90 })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { number: 90 })
+    assert.equal(parsed.duration.unit, 'seconds')
+  })
+
+  it("can accept expressions as the amount (e.g., feed value)", () => {
+    const definition = BlockDefinition.parseRawDefinition(durationDef)
+    
+    // Simulate a feed value being used as the duration amount
+    const mockBlock = {
+      getFieldValue: (field) => {
+        if (field === 'UNIT') return 'minutes'
+        return null
+      },
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ feedValue: { feed: 'delay-time' } })
+    }
+    
+    const [result] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.deepEqual(parsed.duration.amount, { feedValue: { feed: 'delay-time' } })
+    assert.equal(parsed.duration.unit, 'minutes')
+  })
+})

--- a/test/app/blocks/utility_extract_blocks_test.js
+++ b/test/app/blocks/utility_extract_blocks_test.js
@@ -1,0 +1,296 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import extractTimeSegmentDef from "#app/blocks/utility/extract_time_segment.js"
+import extractDateSegmentDef from "#app/blocks/utility/extract_date_segment.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Extract Time Segment Block", () => {
+  it("works", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    assert.equal(definition.type, 'io_utility_extract_time_segment')
+  })
+
+  it("exports block JSON with correct structure", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    const blockJSON = definition.toBlocklyJSON()
+
+    assert.exists(blockJSON.message0)
+    assert.exists(blockJSON.args0)
+    assert.equal(blockJSON.output, 'expression')
+    assert.equal(blockJSON.colour, 360)
+  })
+
+  it("has SEGMENT dropdown with hour, minute, second options", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    const segmentArg = blockJSON.args0.find(arg => arg.name === 'SEGMENT')
+    assert.exists(segmentArg, 'SEGMENT field should exist')
+    assert.equal(segmentArg.type, 'field_dropdown')
+    
+    const optionValues = segmentArg.options.map(opt => opt[1])
+    assert.include(optionValues, 'hour')
+    assert.include(optionValues, 'minute')
+    assert.include(optionValues, 'second')
+  })
+
+  it("has TIME input that accepts time blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    // Block may use multiple message lines, check all args arrays
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const timeArg = allArgs.find(arg => arg.name === 'TIME')
+    assert.exists(timeArg, 'TIME input should exist')
+    assert.equal(timeArg.type, 'input_value')
+    assert.deepEqual(timeArg.check, ['expression', 'time'])
+  })
+
+  it("generates correct JSON for extracting hour", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => field === 'SEGMENT' ? 'hour' : null,
+      timezoneType: 'tz_io_account'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ currentTime: {} })
+    }
+    
+    const [result, precedence] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.equal(precedence, 0)
+    assert.exists(parsed.extractTimeSegment)
+    assert.equal(parsed.extractTimeSegment.segment, 'hour')
+    assert.deepEqual(parsed.extractTimeSegment.time, { currentTime: {} })
+    assert.deepEqual(parsed.extractTimeSegment.timezone, { type: 'tz_io_account' })
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    
+    const blockObject = {
+      extractTimeSegment: {
+        segment: 'minute',
+        time: { currentTime: {} },
+        timezone: { type: 'tz_utc' }
+      }
+    }
+    
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ block: { type: 'io_utility_current_time' } })
+    }
+    
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+    
+    assert.equal(regenerated.type, 'io_utility_extract_time_segment')
+    assert.equal(regenerated.fields.SEGMENT, 'minute')
+    assert.exists(regenerated.inputs.TIME)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_utc')
+  })
+
+  it("throws error when regenerating without extractTimeSegment data", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    
+    assert.throws(() => {
+      definition.regenerators.json({}, {})
+    }, /No extractTimeSegment data/)
+  })
+
+  it("has mutator for timezone configuration", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    assert.exists(definition.mutator, 'should have a mutator')
+  })
+})
+
+
+describe("Extract Date Segment Block", () => {
+  it("works", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    assert.equal(definition.type, 'io_utility_extract_date_segment')
+  })
+
+  it("exports block JSON with correct structure", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    const blockJSON = definition.toBlocklyJSON()
+
+    assert.exists(blockJSON.message0)
+    assert.exists(blockJSON.args0)
+    assert.equal(blockJSON.output, 'expression')
+    assert.equal(blockJSON.colour, 360)
+  })
+
+  it("has SEGMENT dropdown with year, month, day, weekday options", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    const segmentArg = blockJSON.args0.find(arg => arg.name === 'SEGMENT')
+    assert.exists(segmentArg, 'SEGMENT field should exist')
+    assert.equal(segmentArg.type, 'field_dropdown')
+    
+    const optionValues = segmentArg.options.map(opt => opt[1])
+    assert.include(optionValues, 'year')
+    assert.include(optionValues, 'month')
+    assert.include(optionValues, 'day')
+    assert.include(optionValues, 'weekday')
+  })
+
+  it("has DATE input that accepts time blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    const blockJSON = definition.toBlocklyJSON()
+    
+    // Block may use multiple message lines, check all args arrays
+    const allArgs = [...(blockJSON.args0 || []), ...(blockJSON.args1 || [])]
+    const dateArg = allArgs.find(arg => arg.name === 'DATE')
+    assert.exists(dateArg, 'DATE input should exist')
+    assert.equal(dateArg.type, 'input_value')
+    assert.deepEqual(dateArg.check, ['expression', 'time'])
+  })
+
+  it("generates correct JSON for extracting year", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    
+    const mockBlock = {
+      getFieldValue: (field) => field === 'SEGMENT' ? 'year' : null,
+      timezoneType: 'tz_utc'
+    }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ datetime: { day: 14, month: 10, year: 1066 } })
+    }
+    
+    const [result, precedence] = definition.generators.json(mockBlock, mockGenerator)
+    const parsed = JSON.parse(result)
+    
+    assert.equal(precedence, 0)
+    assert.exists(parsed.extractDateSegment)
+    assert.equal(parsed.extractDateSegment.segment, 'year')
+    assert.deepEqual(parsed.extractDateSegment.date, { datetime: { day: 14, month: 10, year: 1066 } })
+    assert.deepEqual(parsed.extractDateSegment.timezone, { type: 'tz_utc' })
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    
+    const blockObject = {
+      extractDateSegment: {
+        segment: 'month',
+        date: { currentTime: {} },
+        timezone: { type: 'tz_io_account' }
+      }
+    }
+    
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ block: { type: 'io_utility_current_time' } })
+    }
+    
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+    
+    assert.equal(regenerated.type, 'io_utility_extract_date_segment')
+    assert.equal(regenerated.fields.SEGMENT, 'month')
+    assert.exists(regenerated.inputs.DATE)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_io_account')
+  })
+
+  it("throws error when regenerating without extractDateSegment data", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    
+    assert.throws(() => {
+      definition.regenerators.json({}, {})
+    }, /No extractDateSegment data/)
+  })
+
+  it("has mutator for timezone configuration", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    assert.exists(definition.mutator, 'should have a mutator')
+  })
+})
+
+
+describe("Extract Blocks - Battle of Hastings (October 14, 1066)", () => {
+  // The Battle of Hastings was fought on October 14, 1066
+  // This is a fun historical test case and also verifies the blocks work with specific dates
+  
+  it("Extract Date Segment can represent the Battle of Hastings date components", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractDateSegmentDef)
+    
+    // Test extracting year = 1066
+    const yearBlock = {
+      getFieldValue: () => 'year',
+      timezoneType: 'tz_utc'
+    }
+    const hastingsTimestamp = { datetime: { day: 14, month: 10, year: 1066, time: null } }
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify(hastingsTimestamp)
+    }
+    
+    const [yearResult] = definition.generators.json(yearBlock, mockGenerator)
+    const yearParsed = JSON.parse(yearResult)
+    assert.equal(yearParsed.extractDateSegment.segment, 'year')
+    // The datetime passed in would evaluate to 1066 when the segment is extracted
+    assert.equal(yearParsed.extractDateSegment.date.datetime.year, 1066)
+    
+    // Test extracting month = October (10)
+    const monthBlock = {
+      getFieldValue: () => 'month',
+      timezoneType: 'tz_utc'
+    }
+    const [monthResult] = definition.generators.json(monthBlock, mockGenerator)
+    const monthParsed = JSON.parse(monthResult)
+    assert.equal(monthParsed.extractDateSegment.segment, 'month')
+    assert.equal(monthParsed.extractDateSegment.date.datetime.month, 10)
+    
+    // Test extracting day = 14
+    const dayBlock = {
+      getFieldValue: () => 'day',
+      timezoneType: 'tz_utc'
+    }
+    const [dayResult] = definition.generators.json(dayBlock, mockGenerator)
+    const dayParsed = JSON.parse(dayResult)
+    assert.equal(dayParsed.extractDateSegment.segment, 'day')
+    assert.equal(dayParsed.extractDateSegment.date.datetime.day, 14)
+    
+    // Test extracting weekday - October 14, 1066 was a Saturday (6 in 0-indexed Sun=0)
+    const weekdayBlock = {
+      getFieldValue: () => 'weekday',
+      timezoneType: 'tz_utc'
+    }
+    const [weekdayResult] = definition.generators.json(weekdayBlock, mockGenerator)
+    const weekdayParsed = JSON.parse(weekdayResult)
+    assert.equal(weekdayParsed.extractDateSegment.segment, 'weekday')
+    // The actual weekday calculation happens at runtime, but the block structure is correct
+  })
+
+  it("Extract Time Segment can work with a morning battle time (e.g., 9:00 AM)", () => {
+    const definition = BlockDefinition.parseRawDefinition(extractTimeSegmentDef)
+    
+    // The battle is said to have started around 9:00 AM
+    // 9:00 AM = 9 hours * 60 minutes * 60 seconds = 32400 seconds since midnight
+    const battleStartTime = { time: { display: '09:00', value: 32400 } }
+    
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify(battleStartTime)
+    }
+    
+    // Extract hour (should be 9)
+    const hourBlock = {
+      getFieldValue: () => 'hour',
+      timezoneType: 'tz_utc'
+    }
+    const [hourResult] = definition.generators.json(hourBlock, mockGenerator)
+    const hourParsed = JSON.parse(hourResult)
+    assert.equal(hourParsed.extractTimeSegment.segment, 'hour')
+    assert.equal(hourParsed.extractTimeSegment.time.time.value, 32400)
+    
+    // Extract minute (should be 0)
+    const minuteBlock = {
+      getFieldValue: () => 'minute',
+      timezoneType: 'tz_utc'
+    }
+    const [minuteResult] = definition.generators.json(minuteBlock, mockGenerator)
+    const minuteParsed = JSON.parse(minuteResult)
+    assert.equal(minuteParsed.extractTimeSegment.segment, 'minute')
+  })
+})

--- a/test/app/blocks/utility_format_blocks_test.js
+++ b/test/app/blocks/utility_format_blocks_test.js
@@ -1,0 +1,178 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import fmtIso8601DefObject from "#app/blocks/utility/format/fmt_iso8601.js"
+import fmtRfc2822DefObject from "#app/blocks/utility/format/fmt_rfc2822.js"
+import fmtUnixDefObject from "#app/blocks/utility/format/fmt_unix.js"
+import fmtPresetDefObject from "#app/blocks/utility/format/fmt_preset.js"
+import fmtCustomDefObject from "#app/blocks/utility/format/fmt_custom.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("DateTime Format Blocks", () => {
+  describe("ISO 8601 Format Block", () => {
+    it("has correct type and output", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtIso8601DefObject)
+
+      assert.equal(definition.type, 'fmt_iso8601')
+      assert.equal(definition.connections.output, 'datetime_format')
+    })
+
+    it("generates correct JSON", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtIso8601DefObject)
+      const result = definition.generators.json()
+
+      assert.exists(result.format)
+      assert.equal(result.format.type, 'iso8601')
+    })
+
+    it("regenerates correctly", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtIso8601DefObject)
+      const regenerated = definition.regenerators.json()
+
+      assert.deepEqual(regenerated, ['fmt_iso8601', {}])
+    })
+  })
+
+  describe("RFC 2822 Format Block", () => {
+    it("has correct type and output", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtRfc2822DefObject)
+
+      assert.equal(definition.type, 'fmt_rfc2822')
+      assert.equal(definition.connections.output, 'datetime_format')
+    })
+
+    it("generates correct JSON", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtRfc2822DefObject)
+      const result = definition.generators.json()
+
+      assert.exists(result.format)
+      assert.equal(result.format.type, 'rfc2822')
+    })
+  })
+
+  describe("Unix Timestamp Format Block", () => {
+    it("has correct type and output", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtUnixDefObject)
+
+      assert.equal(definition.type, 'fmt_unix')
+      assert.equal(definition.connections.output, 'datetime_format')
+    })
+
+    it("generates correct JSON", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtUnixDefObject)
+      const result = definition.generators.json()
+
+      assert.exists(result.format)
+      assert.equal(result.format.type, 'unix')
+    })
+  })
+
+  describe("Preset Format Block", () => {
+    it("has correct type and output", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtPresetDefObject)
+
+      assert.equal(definition.type, 'fmt_preset')
+      assert.equal(definition.connections.output, 'datetime_format')
+    })
+
+    it("has format dropdown with multiple options", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtPresetDefObject)
+
+      assert.exists(definition.fields.FORMAT)
+      assert.exists(definition.fields.FORMAT.options)
+      assert.isArray(definition.fields.FORMAT.options)
+      assert.isAbove(definition.fields.FORMAT.options.length, 5) // Has many presets
+    })
+
+    it("generates correct JSON with preset value", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtPresetDefObject)
+
+      const mockBlock = {
+        getFieldValue: (name) => name === 'FORMAT' ? 'datetime_long' : null
+      }
+
+      const result = definition.generators.json(mockBlock)
+
+      assert.exists(result.format)
+      assert.equal(result.format.type, 'preset')
+      assert.equal(result.format.preset, 'datetime_long')
+    })
+
+    it("regenerates correctly with preset value", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtPresetDefObject)
+
+      const blockObject = {
+        format: { type: 'preset', preset: 'date_short_us' }
+      }
+
+      const regenerated = definition.regenerators.json(blockObject)
+
+      assert.deepEqual(regenerated, ['fmt_preset', { FORMAT: 'date_short_us' }])
+    })
+  })
+
+  describe("Custom strftime Format Block", () => {
+    it("has correct type and output", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtCustomDefObject)
+
+      assert.equal(definition.type, 'fmt_custom')
+      assert.equal(definition.connections.output, 'datetime_format')
+    })
+
+    it("has text field for format string", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtCustomDefObject)
+
+      assert.exists(definition.fields.FORMAT_STRING)
+      assert.exists(definition.fields.FORMAT_STRING.text)
+      assert.equal(definition.fields.FORMAT_STRING.text, '%Y-%m-%d %H:%M:%S')
+    })
+
+    it("generates correct JSON with custom pattern", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtCustomDefObject)
+
+      const mockBlock = {
+        getFieldValue: (name) => name === 'FORMAT_STRING' ? '%B %d, %Y' : null
+      }
+
+      const result = definition.generators.json(mockBlock)
+
+      assert.exists(result.format)
+      assert.equal(result.format.type, 'strftime')
+      assert.equal(result.format.pattern, '%B %d, %Y')
+    })
+
+    it("regenerates correctly with pattern", () => {
+      const definition = BlockDefinition.parseRawDefinition(fmtCustomDefObject)
+
+      const blockObject = {
+        format: { type: 'strftime', pattern: '%H:%M' }
+      }
+
+      const regenerated = definition.regenerators.json(blockObject)
+
+      assert.deepEqual(regenerated, ['fmt_custom', { FORMAT_STRING: '%H:%M' }])
+    })
+  })
+
+  describe("All format blocks", () => {
+    it("all have datetime_format output type for mutator compatibility", () => {
+      const formatBlocks = [
+        fmtIso8601DefObject,
+        fmtRfc2822DefObject,
+        fmtUnixDefObject,
+        fmtPresetDefObject,
+        fmtCustomDefObject
+      ]
+
+      formatBlocks.forEach(blockDef => {
+        const definition = BlockDefinition.parseRawDefinition(blockDef)
+        assert.equal(
+          definition.connections.output, 
+          'datetime_format',
+          `${definition.type} should output datetime_format`
+        )
+      })
+    })
+  })
+})

--- a/test/app/blocks/utility_text_to_datetime_block_test.js
+++ b/test/app/blocks/utility_text_to_datetime_block_test.js
@@ -1,0 +1,137 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import textToDatetimeBlockDefObject from "#app/blocks/utility/text_to_datetime.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Utility Text to DateTime Block", () => {
+  it("works", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    assert.equal(definition.type, 'io_utility_text_to_datetime')
+  })
+
+  it("exports block JSON", () => {
+    const
+      definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject),
+      blockJSON = definition.toBlocklyJSON()
+
+    // contains message and args
+    assert.exists(blockJSON.message0)
+    assert.exists(blockJSON.args0)
+
+    // has proper output types - outputs time type for use with other time blocks
+    assert.deepEqual(blockJSON.output, ['expression', 'time'])
+
+    // has correct color
+    assert.equal(blockJSON.colour, 20)
+    
+    // has mutator defined
+    assert.exists(blockJSON.mutator)
+  })
+
+  it("exports instance JSON with correct type", () => {
+    const
+      definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject),
+      instanceJson = definition.toBlocklyInstanceJSON()
+
+    // has correct type
+    assert.equal(instanceJson.type, 'io_utility_text_to_datetime')
+  })
+
+  it("has INPUT that accepts string blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    // Should accept expression and string types (what text blocks output)
+    assert.deepEqual(definition.inputs.INPUT.check, ['expression', 'string'])
+    
+    // Should have a shadow block with sample ISO date
+    assert.exists(definition.inputs.INPUT.shadow)
+    assert.equal(definition.inputs.INPUT.shadow.type, 'io_text')
+    assert.equal(definition.inputs.INPUT.shadow.fields.TEXT, '2024-01-01T12:00:00Z')
+  })
+
+  it("generates correct JSON output", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    // Mock block object with mutator state
+    const mockBlock = {
+      timezoneType: 'tz_io_server',
+      formatType: 'fmt_custom'
+    }
+
+    // Mock generator
+    const mockGenerator = {
+      valueToCode: () => JSON.stringify({ text: '2024-06-15T09:30:00Z' })
+    }
+
+    const result = definition.generators.json(mockBlock, mockGenerator)
+
+    assert.exists(result.textToDatetime)
+    assert.exists(result.textToDatetime.timezone)
+    assert.equal(result.textToDatetime.timezone.type, 'tz_io_server')
+    assert.exists(result.textToDatetime.format)
+    assert.equal(result.textToDatetime.format.type, 'fmt_custom')
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    const blockObject = {
+      textToDatetime: {
+        input: { text: '2024-12-25T00:00:00Z' },
+        timezone: { type: 'tz_preset' },
+        format: { type: 'fmt_iso8601' }
+      }
+    }
+
+    // Mock helpers
+    const mockHelpers = {
+      expressionToBlock: (expr, opts) => ({ block: { type: opts.shadow?.type || opts.shadow } })
+    }
+
+    const regenerated = definition.regenerators.json(blockObject, mockHelpers)
+
+    assert.equal(regenerated.type, 'io_utility_text_to_datetime')
+    assert.exists(regenerated.extraState)
+    assert.equal(regenerated.extraState.timezoneType, 'tz_preset')
+    assert.equal(regenerated.extraState.formatType, 'fmt_iso8601')
+  })
+
+  it("throws error when regenerating without textToDatetime data", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    const blockObject = {}
+    const mockHelpers = { expressionToBlock: () => ({}) }
+
+    assert.throws(() => {
+      definition.regenerators.json(blockObject, mockHelpers)
+    }, Error, "No textToDatetime data for io_utility_text_to_datetime regenerator")
+  })
+
+  it("has mutator with timezone and format flyout blocks", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    assert.exists(definition.mutator)
+    assert.exists(definition.mutator.flyoutBlockTypes)
+    
+    // Should include timezone option blocks
+    assert.include(definition.mutator.flyoutBlockTypes, 'tz_io_account')
+    assert.include(definition.mutator.flyoutBlockTypes, 'tz_io_server')
+    assert.include(definition.mutator.flyoutBlockTypes, 'tz_preset')
+    
+    // Should include format option blocks
+    assert.include(definition.mutator.flyoutBlockTypes, 'fmt_iso8601')
+    assert.include(definition.mutator.flyoutBlockTypes, 'fmt_rfc2822')
+    assert.include(definition.mutator.flyoutBlockTypes, 'fmt_custom')
+  })
+
+  it("output is compatible with time block inputs", () => {
+    const definition = BlockDefinition.parseRawDefinition(textToDatetimeBlockDefObject)
+
+    // Should output same types as other time blocks for chaining
+    const outputTypes = definition.connections.output
+    assert.includeMembers(outputTypes, ['expression', 'time'])
+  })
+})

--- a/test/app/blocks/utility_time_block_test.js
+++ b/test/app/blocks/utility_time_block_test.js
@@ -1,0 +1,150 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import timeBlockDefObject from "#app/blocks/utility/time.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Utility Time Block", () => {
+  it("works", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+
+    assert.equal(timeDefinition.type, 'io_utility_time')
+  })
+
+  it("exports block JSON", () => {
+    const
+      timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject),
+      timeBlockJSON = timeDefinition.toBlocklyJSON()
+
+    // contains message and args
+    assert.exists(timeBlockJSON.message0)
+    assert.exists(timeBlockJSON.args0)
+
+    // has proper output types
+    assert.deepEqual(timeBlockJSON.output, ['expression', 'time'])
+    
+    // has correct color
+    assert.equal(timeBlockJSON.colour, 360)
+  })
+
+  it("exports instance JSON with correct type", () => {
+    const
+      timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject),
+      timeInstanceJson = timeDefinition.toBlocklyInstanceJSON()
+
+    // has correct type
+    assert.equal(timeInstanceJson.type, 'io_utility_time')
+    
+    // fields are not included in instance JSON by default for dropdown fields
+    assert.notExists(timeInstanceJson.fields)
+  })
+
+  it("generates correct JSON output", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    // Mock block object
+    const mockBlock = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '14'
+        if (fieldName === 'MINUTE') return '30'
+        return null
+      }
+    }
+    
+    const [result, precedence] = timeDefinition.generators.json(mockBlock)
+    const parsedResult = JSON.parse(result)
+    
+    assert.equal(precedence, 0)
+    assert.exists(parsedResult.time)
+    assert.equal(parsedResult.time.display, '14:30')
+    assert.equal(parsedResult.time.value, 870) // 14 * 60 + 30 = 870 minutes since midnight
+  })
+
+  it("regenerates correctly from JSON", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    const blockObject = {
+      time: {
+        display: '09:15',
+        value: 555 // 9 * 60 + 15 = 555 minutes since midnight
+      }
+    }
+    
+    const regenerated = timeDefinition.regenerators.json(blockObject)
+    
+    assert.equal(regenerated.type, 'io_utility_time')
+    assert.equal(regenerated.fields.HOUR, '09')
+    assert.equal(regenerated.fields.MINUTE, '15')
+  })
+
+  it("handles edge cases correctly", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    // Test midnight
+    const mockBlockMidnight = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '00'
+        if (fieldName === 'MINUTE') return '00'
+        return null
+      }
+    }
+    
+    const [midnightResult] = timeDefinition.generators.json(mockBlockMidnight)
+    const parsedMidnight = JSON.parse(midnightResult)
+    
+    assert.equal(parsedMidnight.time.display, '00:00')
+    assert.equal(parsedMidnight.time.value, 0)
+    
+    // Test end of day
+    const mockBlockEndDay = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '23'
+        if (fieldName === 'MINUTE') return '59'
+        return null
+      }
+    }
+    
+    const [endDayResult] = timeDefinition.generators.json(mockBlockEndDay)
+    const parsedEndDay = JSON.parse(endDayResult)
+    
+    assert.equal(parsedEndDay.time.display, '23:59')
+    assert.equal(parsedEndDay.time.value, 1439) // 23 * 60 + 59 = 1439 minutes since midnight
+  })
+
+  it("integrates correctly with comparison blocks", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    // Test that time blocks can be compared with each other
+    const mockBlockA = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '09'
+        if (fieldName === 'MINUTE') return '30'
+        return null
+      }
+    }
+    
+    const mockBlockB = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '17'
+        if (fieldName === 'MINUTE') return '45'
+        return null
+      }
+    }
+    
+    const [resultA] = timeDefinition.generators.json(mockBlockA)
+    const [resultB] = timeDefinition.generators.json(mockBlockB)
+    
+    const parsedA = JSON.parse(resultA)
+    const parsedB = JSON.parse(resultB)
+    
+    // Verify that the numeric values can be compared
+    assert.isTrue(parsedA.time.value < parsedB.time.value, '09:30 should be less than 17:45')
+    assert.equal(parsedA.time.value, 570) // 9 * 60 + 30
+    assert.equal(parsedB.time.value, 1065) // 17 * 60 + 45
+    
+    // Verify display formats are correct
+    assert.equal(parsedA.time.display, '09:30')
+    assert.equal(parsedB.time.display, '17:45')
+  })
+})

--- a/test/app/blocks/utility_time_block_test.js
+++ b/test/app/blocks/utility_time_block_test.js
@@ -58,7 +58,7 @@ describe("Utility Time Block", () => {
     assert.equal(precedence, 0)
     assert.exists(parsedResult.time)
     assert.equal(parsedResult.time.display, '14:30')
-    assert.equal(parsedResult.time.value, 870) // 14 * 60 + 30 = 870 minutes since midnight
+    assert.equal(parsedResult.time.value, 870*60) // 14 * 60 + 30 = 870 minutes since midnight
   })
 
   it("regenerates correctly from JSON", () => {
@@ -67,7 +67,7 @@ describe("Utility Time Block", () => {
     const blockObject = {
       time: {
         display: '09:15',
-        value: 555 // 9 * 60 + 15 = 555 minutes since midnight
+        value: 555*60 // 9 * 60 + 15 = 555 minutes since midnight
       }
     }
     
@@ -109,7 +109,7 @@ describe("Utility Time Block", () => {
     const parsedEndDay = JSON.parse(endDayResult)
     
     assert.equal(parsedEndDay.time.display, '23:59')
-    assert.equal(parsedEndDay.time.value, 1439) // 23 * 60 + 59 = 1439 minutes since midnight
+    assert.equal(parsedEndDay.time.value, 1439*60) // 23 * 60 + 59 = 1439 minutes since midnight
   })
 
   it("integrates correctly with comparison blocks", () => {
@@ -140,8 +140,8 @@ describe("Utility Time Block", () => {
     
     // Verify that the numeric values can be compared
     assert.isTrue(parsedA.time.value < parsedB.time.value, '09:30 should be less than 17:45')
-    assert.equal(parsedA.time.value, 570) // 9 * 60 + 30
-    assert.equal(parsedB.time.value, 1065) // 17 * 60 + 45
+    assert.equal(parsedA.time.value, 570*60) // 9 * 60 + 30 = 570
+    assert.equal(parsedB.time.value, 1065*60) // 17 * 60 + 45 = 1065
     
     // Verify display formats are correct
     assert.equal(parsedA.time.display, '09:30')

--- a/test/app/blocks/utility_time_integration_test.js
+++ b/test/app/blocks/utility_time_integration_test.js
@@ -1,0 +1,168 @@
+import { describe, it } from 'node:test'
+import { assert } from 'chai'
+
+import timeBlockDefObject from "#app/blocks/utility/time.js"
+import currentTimeBlockDefObject from "#app/blocks/utility/current_time.js"
+import compareBlockDefObject from "#app/blocks/math/compare.js"
+import BlockDefinition from "#src/definitions/block_definition.js"
+
+
+describe("Time Blocks Integration", () => {
+  it("Time and Current Time blocks have compatible output types", () => {
+    const
+      timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject),
+      currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    // Both should output the same types for compatibility
+    assert.deepEqual(timeDefinition.connections.output, currentTimeDefinition.connections.output)
+    assert.includeMembers(timeDefinition.connections.output, ['expression', 'time'])
+  })
+
+  it("Time blocks can be used with comparison blocks", () => {
+    const
+      timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject),
+      currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject),
+      compareDefinition = BlockDefinition.parseRawDefinition(compareBlockDefObject)
+
+    // Verify that time blocks output 'expression' type which compare block accepts
+    assert.include(timeDefinition.connections.output, 'expression')
+    assert.include(currentTimeDefinition.connections.output, 'expression')
+    
+    // Compare block should accept 'expression' inputs
+    assert.equal(compareDefinition.inputs.A.check, 'expression')
+    assert.equal(compareDefinition.inputs.B.check, 'expression')
+  })
+
+  it("generates JSON that can be compared mathematically", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    // Create mock blocks for different times
+    const mockEarlyTime = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '09'
+        if (fieldName === 'MINUTE') return '00'
+        return null
+      }
+    }
+    
+    const mockLateTime = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '17'
+        if (fieldName === 'MINUTE') return '30'
+        return null
+      }
+    }
+    
+    const [earlyResult] = timeDefinition.generators.json(mockEarlyTime)
+    const [lateResult] = timeDefinition.generators.json(mockLateTime)
+    
+    const parsedEarly = JSON.parse(earlyResult)
+    const parsedLate = JSON.parse(lateResult)
+    
+    // Verify mathematical comparison works
+    assert.isTrue(parsedEarly.time.value < parsedLate.time.value, '09:00 should be less than 17:30')
+    assert.equal(parsedEarly.time.value, 540) // 9 * 60 = 540
+    assert.equal(parsedLate.time.value, 1050) // 17 * 60 + 30 = 1050
+  })
+
+  it("Current Time block generates compatible JSON structure", () => {
+    const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+    
+    const [result] = currentTimeDefinition.generators.json()
+    const parsedResult = JSON.parse(result)
+    
+    // Should have currentTime object (structure will be handled by backend)
+    assert.exists(parsedResult.currentTime)
+    assert.isObject(parsedResult.currentTime)
+  })
+
+  it("supports common time comparison scenarios", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    // Business hours scenario: 9 AM to 5 PM
+    const startHours = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '09'
+        if (fieldName === 'MINUTE') return '00'
+        return null
+      }
+    }
+    
+    const endHours = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '17'
+        if (fieldName === 'MINUTE') return '00'
+        return null
+      }
+    }
+    
+    const lunch = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '12'
+        if (fieldName === 'MINUTE') return '00'
+        return null
+      }
+    }
+    
+    const [startResult] = timeDefinition.generators.json(startHours)
+    const [endResult] = timeDefinition.generators.json(endHours)
+    const [lunchResult] = timeDefinition.generators.json(lunch)
+    
+    const startTime = JSON.parse(startResult).time.value
+    const endTime = JSON.parse(endResult).time.value
+    const lunchTime = JSON.parse(lunchResult).time.value
+    
+    // Verify logical time ordering
+    assert.isTrue(startTime < lunchTime, 'Start time should be before lunch')
+    assert.isTrue(lunchTime < endTime, 'Lunch should be before end time')
+    assert.isTrue(startTime < endTime, 'Start should be before end')
+    
+    // Verify specific values for common times
+    assert.equal(startTime, 540) // 9:00 = 9 * 60
+    assert.equal(lunchTime, 720) // 12:00 = 12 * 60  
+    assert.equal(endTime, 1020) // 17:00 = 17 * 60
+  })
+
+  it("handles edge cases correctly", () => {
+    const timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject)
+    
+    // Midnight
+    const midnight = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '00'
+        if (fieldName === 'MINUTE') return '00'
+        return null
+      }
+    }
+    
+    // End of day
+    const endOfDay = {
+      getFieldValue: (fieldName) => {
+        if (fieldName === 'HOUR') return '23'
+        if (fieldName === 'MINUTE') return '59'
+        return null
+      }
+    }
+    
+    const [midnightResult] = timeDefinition.generators.json(midnight)
+    const [endOfDayResult] = timeDefinition.generators.json(endOfDay)
+    
+    const midnightValue = JSON.parse(midnightResult).time.value
+    const endOfDayValue = JSON.parse(endOfDayResult).time.value
+    
+    // Verify edge case values
+    assert.equal(midnightValue, 0, 'Midnight should be 0')
+    assert.equal(endOfDayValue, 1439, 'End of day should be 1439 minutes')
+    assert.isTrue(midnightValue < endOfDayValue, 'Midnight should be less than end of day')
+  })
+
+  it("both blocks belong to the same category", () => {
+    const
+      timeDefinition = BlockDefinition.parseRawDefinition(timeBlockDefObject),
+      currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
+
+    // Both blocks should be in Time category and have same color
+    assert.equal(timeDefinition.color, 360)
+    assert.equal(currentTimeDefinition.color, 360)
+  })
+})

--- a/test/app/blocks/utility_time_integration_test.js
+++ b/test/app/blocks/utility_time_integration_test.js
@@ -68,12 +68,18 @@ describe("Time Blocks Integration", () => {
   it("Current Time block generates compatible JSON structure", () => {
     const currentTimeDefinition = BlockDefinition.parseRawDefinition(currentTimeBlockDefObject)
     
-    const [result] = currentTimeDefinition.generators.json()
+    // Generator now expects a block object with timezoneType
+    const mockBlock = {
+      timezoneType: 'tz_io_account'
+    }
+    
+    const [result] = currentTimeDefinition.generators.json(mockBlock)
     const parsedResult = JSON.parse(result)
     
     // Should have currentTime object (structure will be handled by backend)
     assert.exists(parsedResult.currentTime)
     assert.isObject(parsedResult.currentTime)
+    assert.deepEqual(parsedResult.currentTime.timezone, { type: 'tz_io_account' })
   })
 
   it("supports common time comparison scenarios", () => {

--- a/test/app/blocks/utility_time_integration_test.js
+++ b/test/app/blocks/utility_time_integration_test.js
@@ -61,8 +61,8 @@ describe("Time Blocks Integration", () => {
     
     // Verify mathematical comparison works
     assert.isTrue(parsedEarly.time.value < parsedLate.time.value, '09:00 should be less than 17:30')
-    assert.equal(parsedEarly.time.value, 540) // 9 * 60 = 540
-    assert.equal(parsedLate.time.value, 1050) // 17 * 60 + 30 = 1050
+    assert.equal(parsedEarly.time.value, 540 * 60) // 9 * 60 = 540
+    assert.equal(parsedLate.time.value, 1050 * 60) // 17 * 60 + 30 = 1050
   })
 
   it("Current Time block generates compatible JSON structure", () => {
@@ -118,9 +118,9 @@ describe("Time Blocks Integration", () => {
     assert.isTrue(startTime < endTime, 'Start should be before end')
     
     // Verify specific values for common times
-    assert.equal(startTime, 540) // 9:00 = 9 * 60
-    assert.equal(lunchTime, 720) // 12:00 = 12 * 60  
-    assert.equal(endTime, 1020) // 17:00 = 17 * 60
+    assert.equal(startTime, 540 * 60) // 9:00 = 9 * 60 = 540
+    assert.equal(lunchTime, 720 * 60) // 12:00 = 12 * 60 = 720
+    assert.equal(endTime, 1020 * 60) // 17:00 = 17 * 60 = 1020
   })
 
   it("handles edge cases correctly", () => {
@@ -152,7 +152,7 @@ describe("Time Blocks Integration", () => {
     
     // Verify edge case values
     assert.equal(midnightValue, 0, 'Midnight should be 0')
-    assert.equal(endOfDayValue, 1439, 'End of day should be 1439 minutes')
+    assert.equal(endOfDayValue, 1439 * 60, 'End of day should be 1439 minutes')
     assert.isTrue(midnightValue < endOfDayValue, 'Midnight should be less than end of day')
   })
 


### PR DESCRIPTION
The basic premise is all time related blocks will translate to a unix time in seconds (since 1/1/1970).

It should be assumed that all things are in User Timezone, unless stated otherwise (weather block values).
There is a settings cog to allow selecting timezone when appropriate, and also for strftime formatting options.

This is the block list (first two from original PoC by Justin [#34], but updated to work in seconds instead of minutes):
<img width="999" height="1068" alt="image" src="https://github.com/user-attachments/assets/d5544717-2ea7-45a9-8680-dfd61aa95d55" />


Combined with the Create Duration block (e.g. 2days) the user can do time/date arithmetic.

An example of the sunset calculator (2hrs before sunset) and a few block experiments:
<img width="1353" height="935" alt="Screenshot 2025-12-05 162728" src="https://github.com/user-attachments/assets/3c538822-4dd9-4fa9-b4bc-ac2981c2aa98" />

And this is what's inside the format time as text block settings:

<img width="1521" height="1119" alt="image" src="https://github.com/user-attachments/assets/0ab5beee-bb9f-47d0-9cfc-28fe95cacd24" />


To recreate the washing machine monitor project in blocks, it would require accessing the `updated_at` property of a feed, so a new Get Feed Property block was proposed. See https://github.com/adafruit/io-actions/pull/43


